### PR TITLE
Add new fields to Proxy, Plan, Metric and Service.

### DIFF
--- a/client/metric.go
+++ b/client/metric.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateMetric - Creates a metric on a service. All metrics are scoped by service.
-func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name string, unit string) (Metric, error) {
+func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name string, description string, unit string) (Metric, error) {
 	var m Metric
 
 	ep := genMetricCreateListEp(svcId)
@@ -17,6 +17,7 @@ func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name s
 	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 	values.Add("friendly_name", name)
+	values.Add("description", description)
 	values.Add("unit", unit)
 
 	body := strings.NewReader(values.Encode())

--- a/client/plan.go
+++ b/client/plan.go
@@ -43,7 +43,7 @@ func (c *ThreeScaleClient) CreateAppPlan(accessToken string, svcId string, name 
 }
 
 // UpdateAppPlan - Updates an application plan
-func (c *ThreeScaleClient) UpdateAppPlan(accessToken string, svcId string, appPlanId string, name string, stateEvent string) (Plan, error) {
+func (c *ThreeScaleClient) UpdateAppPlan(accessToken string, svcId string, appPlanId string, name string, stateEvent string, params Params) (Plan, error) {
 	endpoint := fmt.Sprintf(appPlanUpdateDelete, svcId, appPlanId)
 
 	values := url.Values{}
@@ -51,6 +51,9 @@ func (c *ThreeScaleClient) UpdateAppPlan(accessToken string, svcId string, appPl
 	values.Add("service_id", svcId)
 	values.Add("name", name)
 	values.Add("state_event", stateEvent)
+	for k, v := range params {
+		values.Add(k, v)
+	}
 
 	return c.updatePlan(endpoint, accessToken, values)
 }

--- a/client/services.go
+++ b/client/services.go
@@ -39,7 +39,7 @@ func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Servi
 
 // UpdateService         - Update the service. Valid params keys and their purpose are as follows:
 // "name"                - Name of the service.
-// "description"		 - Description of the service
+// "description"         - Description of the service
 // "support_email"       - New support email.
 // "tech_support_email"  - New tech support email.
 // "admin_support_email" - New admin support email.

--- a/client/services.go
+++ b/client/services.go
@@ -39,6 +39,7 @@ func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Servi
 
 // UpdateService - Update the service. Valid params keys and their purpose are as follows:
 // "name"                - Name of the service.
+// "description"		 - Description of the service
 // "support_email"       - New support email.
 // "tech_support_email"  - New tech support email.
 // "admin_support_email" - New admin support email.

--- a/client/services.go
+++ b/client/services.go
@@ -37,7 +37,7 @@ func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Servi
 	return s, err
 }
 
-// UpdateService - Update the service. Valid params keys and their purpose are as follows:
+// UpdateService         - Update the service. Valid params keys and their purpose are as follows:
 // "name"                - Name of the service.
 // "description"		 - Description of the service
 // "support_email"       - New support email.

--- a/client/types.go
+++ b/client/types.go
@@ -144,6 +144,7 @@ type Proxy struct {
 	CreatedAt               string   `xml:"created_at"`
 	UpdatedAt               string   `xml:"updated_at"`
 	LockVersion             string   `xml:"lock_version"`
+	OidcIssuerEndpoint      string   `xml:"oidc_issuer_endpoint"`
 }
 
 type Service struct {

--- a/client/types.go
+++ b/client/types.go
@@ -150,6 +150,8 @@ type Service struct {
 	ID                          string     `xml:"id"`
 	AccountID                   string     `xml:"account_id"`
 	Name                        string     `xml:"name"`
+	Description                 string     `xml:"description"`
+	DeploymentOption            string     `xml:"deployment_option"`
 	State                       string     `xml:"state"`
 	SystemName                  string     `xml:"system_name"`
 	BackendVersion              string     `xml:"backend_version"`

--- a/client/types.go
+++ b/client/types.go
@@ -111,6 +111,7 @@ type Plan struct {
 	State              string   `xml:"state"`
 	ServiceID          string   `xml:"service_id"`
 	EndUserRequired    string   `xml:"end_user_required"`
+	ApprovalRequired   string   `xml:"approval_required"`
 	SetupFee           string   `xml:"setup_fee"`
 	CostPerMonth       string   `xml:"cost_per_month"`
 	TrialPeriodDays    string   `xml:"trial_period_days"`


### PR DESCRIPTION
Working on the 3scale-operator we found out that some information from the
3scale API is not available in the client due to missing fields.