### PR TITLE
Use basic auth to authenticate with 3scale Porta

### DIFF
--- a/client/accounts.go
+++ b/client/accounts.go
@@ -9,8 +9,8 @@ const (
 	accountList = "/admin/api/accounts.xml"
 )
 
-func (c *ThreeScaleClient) ListAccounts(credential string) (*AccountList, error) {
-	req, err := c.buildGetReq(accountList, credential)
+func (c *ThreeScaleClient) ListAccounts() (*AccountList, error) {
+	req, err := c.buildGetReq(accountList)
 	if err != nil {
 		return nil, err
 	}

--- a/client/accounts.go
+++ b/client/accounts.go
@@ -9,15 +9,13 @@ const (
 	accountList = "/admin/api/accounts.xml"
 )
 
-func (c *ThreeScaleClient) ListAccounts(accessToken string) (*AccountList, error) {
-	req, err := c.buildGetReq(accountList)
+func (c *ThreeScaleClient) ListAccounts(credential string) (*AccountList, error) {
+	req, err := c.buildGetReq(accountList, credential)
 	if err != nil {
 		return nil, err
 	}
 
 	urlValues := url.Values{}
-	urlValues.Add("access_token", accessToken)
-
 	req.URL.RawQuery = urlValues.Encode()
 
 	resp, err := c.httpClient.Do(req)

--- a/client/accounts_test.go
+++ b/client/accounts_test.go
@@ -34,9 +34,9 @@ func TestListAccountsOk(t *testing.T) {
 		}
 	})
 
-	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
 
-	accountList, err := c.ListAccounts(credential)
+	accountList, err := c.ListAccounts()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -76,8 +76,8 @@ func TestListAccountsErrors(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			})
-			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			_, err := c.ListAccounts(credential)
+			c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+			_, err := c.ListAccounts()
 			if err == nil {
 				t.Fatalf("account list did not return error")
 			}

--- a/client/accounts_test.go
+++ b/client/accounts_test.go
@@ -9,15 +9,21 @@ import (
 )
 
 func TestListAccountsOk(t *testing.T) {
-	access_token := "someAccessToken"
+	credential := "someAccessToken"
 	httpClient := NewTestClient(func(req *http.Request) *http.Response {
 		if req.Method != http.MethodGet {
 			t.Fatalf("wrong helper called for account list api")
 		}
 
-		q := req.URL.Query()
-		if q.Get("access_token") != access_token {
-			t.Fatalf("Expected access token not found")
+		auth := strings.SplitN(req.Header.Get("Authorization"), " ", 2)
+
+		if len(auth) != 2 || auth[0] != "Basic" {
+			t.Fatalf("Basic auth header missing or not valid")
+		}
+
+		expectedAuth := basicAuth("", credential)
+		if auth[1] != expectedAuth {
+			t.Fatalf("Invalid authorization header value, expected %s got %s", expectedAuth, auth[1])
 		}
 
 		bodyReader := bytes.NewReader(helperLoadBytes(t, "accounts_fixture.xml"))
@@ -30,7 +36,7 @@ func TestListAccountsOk(t *testing.T) {
 
 	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
 
-	accountList, err := c.ListAccounts(access_token)
+	accountList, err := c.ListAccounts(credential)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -46,7 +52,7 @@ func TestListAccountsOk(t *testing.T) {
 }
 
 func TestListAccountsErrors(t *testing.T) {
-	access_token := "someAccessToken"
+	credential := "someAccessToken"
 	errorTests := []struct {
 		Name                string
 		ResponseBodyFixture string
@@ -71,7 +77,7 @@ func TestListAccountsErrors(t *testing.T) {
 				}
 			})
 			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			_, err := c.ListAccounts(access_token)
+			_, err := c.ListAccounts(credential)
 			if err == nil {
 				t.Fatalf("account list did not return error")
 			}

--- a/client/app.go
+++ b/client/app.go
@@ -13,19 +13,18 @@ const (
 
 // CreateApp - Create an application.
 // The application object can be extended with Fields Definitions in the Admin Portal where you can add/remove fields
-func (c *ThreeScaleClient) CreateApp(accessToken string, accountId string, planId string, name string, description string) (Application, error) {
+func (c *ThreeScaleClient) CreateApp(credential string, accountId string, planId string, name string, description string) (Application, error) {
 	var apiResp Application
 	endpoint := fmt.Sprintf(appCreate, accountId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("account_id", accountId)
 	values.Add("plan_id", planId)
 	values.Add("name", name)
 	values.Add("description", description)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, body)
+	req, err := c.buildPostReq(endpoint, credential, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}

--- a/client/app.go
+++ b/client/app.go
@@ -13,7 +13,7 @@ const (
 
 // CreateApp - Create an application.
 // The application object can be extended with Fields Definitions in the Admin Portal where you can add/remove fields
-func (c *ThreeScaleClient) CreateApp(credential string, accountId string, planId string, name string, description string) (Application, error) {
+func (c *ThreeScaleClient) CreateApp(accountId string, planId string, name string, description string) (Application, error) {
 	var apiResp Application
 	endpoint := fmt.Sprintf(appCreate, accountId)
 
@@ -24,7 +24,7 @@ func (c *ThreeScaleClient) CreateApp(credential string, accountId string, planId
 	values.Add("description", description)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, credential, body)
+	req, err := c.buildPostReq(endpoint, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -48,10 +48,10 @@ func TestCreateApp(t *testing.T) {
 			return fake.CreateAppSuccess(input.name)
 		})
 
-		c := NewThreeScale(NewTestAdminPortal(t), httpClient)
+		c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
 
 		t.Run(input.name, func(t *testing.T) {
-			a, b := c.CreateApp(credential, accountID, planID, name, input.name)
+			a, b := c.CreateApp(accountID, planID, name, input.name)
 			if input.returnErr {
 				e := b.(ApiErr)
 				if e.Code() != http.StatusForbidden {

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestCreateApp(t *testing.T) {
 	const (
-		accessToken = "123"
+		credential  = "123"
 		accountID   = "321"
 		planID      = "abc"
 		name        = "test"
@@ -51,7 +51,7 @@ func TestCreateApp(t *testing.T) {
 		c := NewThreeScale(NewTestAdminPortal(t), httpClient)
 
 		t.Run(input.name, func(t *testing.T) {
-			a, b := c.CreateApp(accessToken, accountID, planID, name, input.name)
+			a, b := c.CreateApp(credential, accountID, planID, name, input.name)
 			if input.returnErr {
 				e := b.(ApiErr)
 				if e.Code() != http.StatusForbidden {

--- a/client/client.go
+++ b/client/client.go
@@ -35,11 +35,11 @@ func NewAdminPortal(scheme string, host string, port int) (*AdminPortal, error) 
 
 // Creates a ThreeScaleClient to communicate with Account Management API.
 // If http Client is nil, the default http client will be used
-func NewThreeScale(backEnd *AdminPortal, httpClient *http.Client) *ThreeScaleClient {
+func NewThreeScale(backEnd *AdminPortal, credential string, httpClient *http.Client) *ThreeScaleClient {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &ThreeScaleClient{backEnd, httpClient}
+	return &ThreeScaleClient{backEnd, credential, httpClient}
 }
 
 func NewParams() Params {
@@ -60,51 +60,51 @@ func (p Params) AddParam(key string, value string) {
 }
 
 // Request builder for GET request to the provided endpoint
-func (c *ThreeScaleClient) buildGetReq(ep string, credential string) (*http.Request, error) {
+func (c *ThreeScaleClient) buildGetReq(ep string) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("GET", c.adminPortal.baseUrl.ResolveReference(path).String(), nil)
 	req.Header.Set("Accept", "application/xml")
-	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
+	req.Header.Set("Authorization", "Basic "+basicAuth("", c.credential))
 	return req, err
 }
 
 // Request builder for POST request to the provided endpoint
-func (c *ThreeScaleClient) buildPostReq(ep string, credential string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildPostReq(ep string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("POST", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
+	req.Header.Set("Authorization", "Basic "+basicAuth("", c.credential))
 	return req, err
 }
 
 // Request builder for PUT request to the provided endpoint
-func (c *ThreeScaleClient) buildUpdateReq(ep string, credential string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildUpdateReq(ep string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("PUT", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
+	req.Header.Set("Authorization", "Basic "+basicAuth("", c.credential))
 	return req, err
 }
 
 // Request builder for DELETE request to the provided endpoint
-func (c *ThreeScaleClient) buildDeleteReq(ep string, credential string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildDeleteReq(ep string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("DELETE", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
+	req.Header.Set("Authorization", "Basic "+basicAuth("", c.credential))
 	return req, err
 }
 
 // Request builder for PUT request to the provided endpoint
-func (c *ThreeScaleClient) buildPutReq(ep string, credential string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildPutReq(ep string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("PUT", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
+	req.Header.Set("Authorization", "Basic "+basicAuth("", c.credential))
 	return req, err
 }
 

--- a/client/client.go
+++ b/client/client.go
@@ -59,6 +59,11 @@ func (p Params) AddParam(key string, value string) {
 	p[key] = value
 }
 
+// SetCredentials allow the user to set the client credentials
+func (c *ThreeScaleClient) SetCredentials(credential string) {
+	c.credential = credential
+}
+
 // Request builder for GET request to the provided endpoint
 func (c *ThreeScaleClient) buildGetReq(ep string) (*http.Request, error) {
 	path := &url.URL{Path: ep}

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client
 // which is a subset of the Account Management API.
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"errors"
@@ -59,46 +60,51 @@ func (p Params) AddParam(key string, value string) {
 }
 
 // Request builder for GET request to the provided endpoint
-func (c *ThreeScaleClient) buildGetReq(ep string) (*http.Request, error) {
+func (c *ThreeScaleClient) buildGetReq(ep string, credential string) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("GET", c.adminPortal.baseUrl.ResolveReference(path).String(), nil)
 	req.Header.Set("Accept", "application/xml")
+	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
 	return req, err
 }
 
 // Request builder for POST request to the provided endpoint
-func (c *ThreeScaleClient) buildPostReq(ep string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildPostReq(ep string, credential string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("POST", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
 	return req, err
 }
 
 // Request builder for PUT request to the provided endpoint
-func (c *ThreeScaleClient) buildUpdateReq(ep string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildUpdateReq(ep string, credential string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("PUT", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
 	return req, err
 }
 
 // Request builder for DELETE request to the provided endpoint
-func (c *ThreeScaleClient) buildDeleteReq(ep string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildDeleteReq(ep string, credential string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("DELETE", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
 	return req, err
 }
 
 // Request builder for PUT request to the provided endpoint
-func (c *ThreeScaleClient) buildPutReq(ep string, body io.Reader) (*http.Request, error) {
+func (c *ThreeScaleClient) buildPutReq(ep string, credential string, body io.Reader) (*http.Request, error) {
 	path := &url.URL{Path: ep}
 	req, err := http.NewRequest("PUT", c.adminPortal.baseUrl.ResolveReference(path).String(), body)
 	req.Header.Set("Accept", "application/xml")
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Authorization", "Basic "+basicAuth("", credential))
 	return req, err
 }
 
@@ -186,4 +192,9 @@ func createApiErr(statusCode int, message string) ApiErr {
 
 func createDecodingErrorMessage(err error) string {
 	return fmt.Sprintf("decoding error - %s", err.Error())
+}
+
+func basicAuth(username, password string) string {
+	auth := username + ":" + password
+	return base64.StdEncoding.EncodeToString([]byte(auth))
 }

--- a/client/limit.go
+++ b/client/limit.go
@@ -19,84 +19,83 @@ const (
 
 // CreateLimitAppPlan - Adds a limit to a metric of an application plan.
 // All applications with the application plan (application_plan_id) will be constrained by this new limit on the metric (metric_id).
-func (c *ThreeScaleClient) CreateLimitAppPlan(accessToken string, appPlanId string, metricId string, period string, value int) (Limit, error) {
+func (c *ThreeScaleClient) CreateLimitAppPlan(credential string, appPlanId string, metricId string, period string, value int) (Limit, error) {
 	endpoint := fmt.Sprintf(limitAppPlanCreate, appPlanId, metricId)
 
 	values := url.Values{}
 	values.Add("application_plan_id", appPlanId)
 
-	return c.limitCreate(endpoint, accessToken, metricId, period, value, values)
+	return c.limitCreate(endpoint, credential, metricId, period, value, values)
 }
 
 // CreateLimitEndUserPlan - Adds a limit to a metric of an end user plan
 // All applications with the application plan (end_user_plan_id) will be constrained by this new limit on the metric (metric_id).
-func (c *ThreeScaleClient) CreateLimitEndUserPlan(accessToken string, endUserPlanId string, metricId string, period string, value int) (Limit, error) {
+func (c *ThreeScaleClient) CreateLimitEndUserPlan(credential string, endUserPlanId string, metricId string, period string, value int) (Limit, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanCreateList, endUserPlanId, metricId)
 
 	values := url.Values{}
 	values.Add("end_user_plan_id", endUserPlanId)
 
-	return c.limitCreate(endpoint, accessToken, metricId, period, value, values)
+	return c.limitCreate(endpoint, credential, metricId, period, value, values)
 }
 
 // UpdateLimitsPerPlan - Updates a limit on a metric of an end user plan
 // Valid params keys and their purpose are as follows:
 // "period" - Period of the limit
 // "value"  - Value of the limit
-func (c *ThreeScaleClient) UpdateLimitPerAppPlan(accessToken string, appPlanId string, metricId string, limitId string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) UpdateLimitPerAppPlan(credential string, appPlanId string, metricId string, limitId string, p Params) (Limit, error) {
 	endpoint := fmt.Sprintf(limitAppPlanUpdateDelete, appPlanId, metricId, limitId)
-	return c.updateLimit(endpoint, accessToken, p)
+	return c.updateLimit(endpoint, credential, p)
 }
 
 // UpdateLimitsPerMetric - Updates a limit on a metric of an application plan
 // Valid params keys and their purpose are as follows:
 // "period" - Period of the limit
 // "value"  - Value of the limit
-func (c *ThreeScaleClient) UpdateLimitPerEndUserPlan(accessToken string, userPlanId string, metricId string, limitId string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) UpdateLimitPerEndUserPlan(credential string, userPlanId string, metricId string, limitId string, p Params) (Limit, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanUpdateDelete, userPlanId, metricId, limitId)
-	return c.updateLimit(endpoint, accessToken, p)
+	return c.updateLimit(endpoint, credential, p)
 }
 
 // DeleteLimitPerAppPlan - Deletes a limit on a metric of an application plan
-func (c *ThreeScaleClient) DeleteLimitPerAppPlan(accessToken string, appPlanId string, metricId string, limitId string) error {
+func (c *ThreeScaleClient) DeleteLimitPerAppPlan(credential string, appPlanId string, metricId string, limitId string) error {
 	endpoint := fmt.Sprintf(limitAppPlanUpdateDelete, appPlanId, metricId, limitId)
-	return c.deleteLimit(endpoint, accessToken)
+	return c.deleteLimit(endpoint, credential)
 }
 
 // DeleteLimitPerEndUserPlan - Deletes a limit on a metric of an end user plan
-func (c *ThreeScaleClient) DeleteLimitPerEndUserPlan(accessToken string, userPlanId string, metricId string, limitId string) error {
+func (c *ThreeScaleClient) DeleteLimitPerEndUserPlan(credential string, userPlanId string, metricId string, limitId string) error {
 	endpoint := fmt.Sprintf(limitEndUserPlanUpdateDelete, userPlanId, metricId, limitId)
-	return c.deleteLimit(endpoint, accessToken)
+	return c.deleteLimit(endpoint, credential)
 }
 
 // ListLimitsPerAppPlan - Returns the list of all limits associated to an application plan.
-func (c *ThreeScaleClient) ListLimitsPerAppPlan(accessToken string, appPlanId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerAppPlan(credential string, appPlanId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitAppPlanList, appPlanId)
-	return c.listLimits(endpoint, accessToken)
+	return c.listLimits(endpoint, credential)
 }
 
 // ListLimitsPerEndUserPlan - Returns the list of all limits associated to an end user plan.
-func (c *ThreeScaleClient) ListLimitsPerEndUserPlan(accessToken string, endUserPlanId string, metricId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerEndUserPlan(credential string, endUserPlanId string, metricId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanCreateList, endUserPlanId, metricId)
-	return c.listLimits(endpoint, accessToken)
+	return c.listLimits(endpoint, credential)
 }
 
 // ListLimitsPerMetric - Returns the list of all limits associated to a metric of an application plan
-func (c *ThreeScaleClient) ListLimitsPerMetric(accessToken string, appPlanId string, metricId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerMetric(credential string, appPlanId string, metricId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitAppPlanMetricList, appPlanId, metricId)
-	return c.listLimits(endpoint, accessToken)
+	return c.listLimits(endpoint, credential)
 }
 
-func (c *ThreeScaleClient) limitCreate(ep string, accessToken string, metricId string, period string, value int, values url.Values) (Limit, error) {
+func (c *ThreeScaleClient) limitCreate(ep string, credential string, metricId string, period string, value int, values url.Values) (Limit, error) {
 	var apiResp Limit
 
-	values.Add("access_token", accessToken)
 	values.Add("metric_id", metricId)
 	values.Add("period", period)
 	values.Add("value", strconv.Itoa(value))
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(ep, body)
+	req, err := c.buildPostReq(ep, credential, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}
@@ -111,16 +110,15 @@ func (c *ThreeScaleClient) limitCreate(ep string, accessToken string, metricId s
 	return apiResp, err
 }
 
-func (c *ThreeScaleClient) updateLimit(ep string, accessToken string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) updateLimit(ep string, credential string, p Params) (Limit, error) {
 	var l Limit
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	for k, v := range p {
 		values.Add(k, v)
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, body)
+	req, err := c.buildUpdateReq(ep, credential, body)
 	if err != nil {
 		return l, httpReqError
 	}
@@ -136,12 +134,10 @@ func (c *ThreeScaleClient) updateLimit(ep string, accessToken string, p Params) 
 	return l, err
 }
 
-func (c *ThreeScaleClient) deleteLimit(ep string, accessToken string) error {
+func (c *ThreeScaleClient) deleteLimit(ep string, credential string) error {
 	values := url.Values{}
-	values.Add("access_token", accessToken)
-
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(ep, body)
+	req, err := c.buildDeleteReq(ep, credential, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -156,16 +152,15 @@ func (c *ThreeScaleClient) deleteLimit(ep string, accessToken string) error {
 }
 
 // listLimits takes an endpoint and returns a list of limits
-func (c *ThreeScaleClient) listLimits(ep string, accessToken string) (LimitList, error) {
+func (c *ThreeScaleClient) listLimits(ep string, credential string) (LimitList, error) {
 	var ml LimitList
 
-	req, err := c.buildGetReq(ep)
+	req, err := c.buildGetReq(ep, credential)
 	if err != nil {
 		return ml, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)

--- a/client/limit.go
+++ b/client/limit.go
@@ -19,75 +19,75 @@ const (
 
 // CreateLimitAppPlan - Adds a limit to a metric of an application plan.
 // All applications with the application plan (application_plan_id) will be constrained by this new limit on the metric (metric_id).
-func (c *ThreeScaleClient) CreateLimitAppPlan(credential string, appPlanId string, metricId string, period string, value int) (Limit, error) {
+func (c *ThreeScaleClient) CreateLimitAppPlan(appPlanId string, metricId string, period string, value int) (Limit, error) {
 	endpoint := fmt.Sprintf(limitAppPlanCreate, appPlanId, metricId)
 
 	values := url.Values{}
 	values.Add("application_plan_id", appPlanId)
 
-	return c.limitCreate(endpoint, credential, metricId, period, value, values)
+	return c.limitCreate(endpoint, metricId, period, value, values)
 }
 
 // CreateLimitEndUserPlan - Adds a limit to a metric of an end user plan
 // All applications with the application plan (end_user_plan_id) will be constrained by this new limit on the metric (metric_id).
-func (c *ThreeScaleClient) CreateLimitEndUserPlan(credential string, endUserPlanId string, metricId string, period string, value int) (Limit, error) {
+func (c *ThreeScaleClient) CreateLimitEndUserPlan(endUserPlanId string, metricId string, period string, value int) (Limit, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanCreateList, endUserPlanId, metricId)
 
 	values := url.Values{}
 	values.Add("end_user_plan_id", endUserPlanId)
 
-	return c.limitCreate(endpoint, credential, metricId, period, value, values)
+	return c.limitCreate(endpoint,  metricId, period, value, values)
 }
 
 // UpdateLimitsPerPlan - Updates a limit on a metric of an end user plan
 // Valid params keys and their purpose are as follows:
 // "period" - Period of the limit
 // "value"  - Value of the limit
-func (c *ThreeScaleClient) UpdateLimitPerAppPlan(credential string, appPlanId string, metricId string, limitId string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) UpdateLimitPerAppPlan(appPlanId string, metricId string, limitId string, p Params) (Limit, error) {
 	endpoint := fmt.Sprintf(limitAppPlanUpdateDelete, appPlanId, metricId, limitId)
-	return c.updateLimit(endpoint, credential, p)
+	return c.updateLimit(endpoint, p)
 }
 
 // UpdateLimitsPerMetric - Updates a limit on a metric of an application plan
 // Valid params keys and their purpose are as follows:
 // "period" - Period of the limit
 // "value"  - Value of the limit
-func (c *ThreeScaleClient) UpdateLimitPerEndUserPlan(credential string, userPlanId string, metricId string, limitId string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) UpdateLimitPerEndUserPlan(userPlanId string, metricId string, limitId string, p Params) (Limit, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanUpdateDelete, userPlanId, metricId, limitId)
-	return c.updateLimit(endpoint, credential, p)
+	return c.updateLimit(endpoint, p)
 }
 
 // DeleteLimitPerAppPlan - Deletes a limit on a metric of an application plan
-func (c *ThreeScaleClient) DeleteLimitPerAppPlan(credential string, appPlanId string, metricId string, limitId string) error {
+func (c *ThreeScaleClient) DeleteLimitPerAppPlan(appPlanId string, metricId string, limitId string) error {
 	endpoint := fmt.Sprintf(limitAppPlanUpdateDelete, appPlanId, metricId, limitId)
-	return c.deleteLimit(endpoint, credential)
+	return c.deleteLimit(endpoint)
 }
 
 // DeleteLimitPerEndUserPlan - Deletes a limit on a metric of an end user plan
-func (c *ThreeScaleClient) DeleteLimitPerEndUserPlan(credential string, userPlanId string, metricId string, limitId string) error {
+func (c *ThreeScaleClient) DeleteLimitPerEndUserPlan(userPlanId string, metricId string, limitId string) error {
 	endpoint := fmt.Sprintf(limitEndUserPlanUpdateDelete, userPlanId, metricId, limitId)
-	return c.deleteLimit(endpoint, credential)
+	return c.deleteLimit(endpoint)
 }
 
 // ListLimitsPerAppPlan - Returns the list of all limits associated to an application plan.
-func (c *ThreeScaleClient) ListLimitsPerAppPlan(credential string, appPlanId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerAppPlan(appPlanId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitAppPlanList, appPlanId)
-	return c.listLimits(endpoint, credential)
+	return c.listLimits(endpoint)
 }
 
 // ListLimitsPerEndUserPlan - Returns the list of all limits associated to an end user plan.
-func (c *ThreeScaleClient) ListLimitsPerEndUserPlan(credential string, endUserPlanId string, metricId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerEndUserPlan(endUserPlanId string, metricId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitEndUserPlanCreateList, endUserPlanId, metricId)
-	return c.listLimits(endpoint, credential)
+	return c.listLimits(endpoint)
 }
 
 // ListLimitsPerMetric - Returns the list of all limits associated to a metric of an application plan
-func (c *ThreeScaleClient) ListLimitsPerMetric(credential string, appPlanId string, metricId string) (LimitList, error) {
+func (c *ThreeScaleClient) ListLimitsPerMetric(appPlanId string, metricId string) (LimitList, error) {
 	endpoint := fmt.Sprintf(limitAppPlanMetricList, appPlanId, metricId)
-	return c.listLimits(endpoint, credential)
+	return c.listLimits(endpoint)
 }
 
-func (c *ThreeScaleClient) limitCreate(ep string, credential string, metricId string, period string, value int, values url.Values) (Limit, error) {
+func (c *ThreeScaleClient) limitCreate(ep string, metricId string, period string, value int, values url.Values) (Limit, error) {
 	var apiResp Limit
 
 	values.Add("metric_id", metricId)
@@ -95,7 +95,7 @@ func (c *ThreeScaleClient) limitCreate(ep string, credential string, metricId st
 	values.Add("value", strconv.Itoa(value))
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(ep, credential, body)
+	req, err := c.buildPostReq(ep, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}
@@ -110,7 +110,7 @@ func (c *ThreeScaleClient) limitCreate(ep string, credential string, metricId st
 	return apiResp, err
 }
 
-func (c *ThreeScaleClient) updateLimit(ep string, credential string, p Params) (Limit, error) {
+func (c *ThreeScaleClient) updateLimit(ep string, p Params) (Limit, error) {
 	var l Limit
 	values := url.Values{}
 	for k, v := range p {
@@ -118,7 +118,7 @@ func (c *ThreeScaleClient) updateLimit(ep string, credential string, p Params) (
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, credential, body)
+	req, err := c.buildUpdateReq(ep, body)
 	if err != nil {
 		return l, httpReqError
 	}
@@ -134,10 +134,10 @@ func (c *ThreeScaleClient) updateLimit(ep string, credential string, p Params) (
 	return l, err
 }
 
-func (c *ThreeScaleClient) deleteLimit(ep string, credential string) error {
+func (c *ThreeScaleClient) deleteLimit(ep string) error {
 	values := url.Values{}
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(ep, credential, body)
+	req, err := c.buildDeleteReq(ep, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -152,10 +152,10 @@ func (c *ThreeScaleClient) deleteLimit(ep string, credential string) error {
 }
 
 // listLimits takes an endpoint and returns a list of limits
-func (c *ThreeScaleClient) listLimits(ep string, credential string) (LimitList, error) {
+func (c *ThreeScaleClient) listLimits(ep string) (LimitList, error) {
 	var ml LimitList
 
-	req, err := c.buildGetReq(ep, credential)
+	req, err := c.buildGetReq(ep)
 	if err != nil {
 		return ml, httpReqError
 	}

--- a/client/mapping.go
+++ b/client/mapping.go
@@ -10,7 +10,7 @@ import (
 
 // CreateMappingRule - Create API for Mapping Rule endpoint
 func (c *ThreeScaleClient) CreateMappingRule(
-	credential string, svcId string, method string,
+	svcId string, method string,
 	pattern string, delta int, metricId string) (MappingRule, error) {
 
 	var mr MappingRule

--- a/client/mapping.go
+++ b/client/mapping.go
@@ -10,14 +10,13 @@ import (
 
 // CreateMappingRule - Create API for Mapping Rule endpoint
 func (c *ThreeScaleClient) CreateMappingRule(
-	accessToken string, svcId string, method string,
+	credential string, svcId string, method string,
 	pattern string, delta int, metricId string) (MappingRule, error) {
 
 	var mr MappingRule
 	ep := genMrEp(svcId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 	values.Add("http_method", method)
 	values.Add("pattern", pattern)
@@ -25,7 +24,7 @@ func (c *ThreeScaleClient) CreateMappingRule(
 	values.Add("metric_id", metricId)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(ep, body)
+	req, err := c.buildPostReq(ep, credential, body)
 	if err != nil {
 		return mr, httpReqError
 	}
@@ -48,19 +47,18 @@ func (c *ThreeScaleClient) CreateMappingRule(
 // "pattern"     - Mapping Rule pattern
 // "delta"       - Increase the metric by this delta
 // "metric_id"   - The metric ID
-func (c *ThreeScaleClient) UpdateMappingRule(accessToken string, svcId string, id string, params Params) (MappingRule, error) {
+func (c *ThreeScaleClient) UpdateMappingRule(credential string, svcId string, id string, params Params) (MappingRule, error) {
 	var m MappingRule
 
 	ep := genMrUpdateEp(svcId, id)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	for k, v := range params {
 		values.Add(k, v)
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, body)
+	req, err := c.buildUpdateReq(ep, credential, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -78,14 +76,11 @@ func (c *ThreeScaleClient) UpdateMappingRule(accessToken string, svcId string, i
 
 // DeleteMappingRule - Deletes a Proxy Mapping Rule.
 // The proxy object must be updated after a mapping rule deletion to apply the change to proxy config
-func (c *ThreeScaleClient) DeleteMappingRule(accessToken string, svcId string, id string) error {
+func (c *ThreeScaleClient) DeleteMappingRule(credential string, svcId string, id string) error {
 	ep := genMrUpdateEp(svcId, id)
 
-	values := url.Values{}
-	values.Add("access_token", accessToken)
-
-	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(ep, body)
+	body := strings.NewReader("")
+	req, err := c.buildDeleteReq(ep, credential, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -101,17 +96,16 @@ func (c *ThreeScaleClient) DeleteMappingRule(accessToken string, svcId string, i
 }
 
 // ListMappingRule - List API for Mapping Rule endpoint
-func (c *ThreeScaleClient) ListMappingRule(accessToken string, svcId string) (MappingRuleList, error) {
+func (c *ThreeScaleClient) ListMappingRule(credential string, svcId string) (MappingRuleList, error) {
 	var mrl MappingRuleList
 	ep := genMrEp(svcId)
 
-	req, err := c.buildGetReq(ep)
+	req, err := c.buildGetReq(ep, credential)
 	if err != nil {
 		return mrl, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 
 	req.URL.RawQuery = values.Encode()

--- a/client/mapping.go
+++ b/client/mapping.go
@@ -24,7 +24,7 @@ func (c *ThreeScaleClient) CreateMappingRule(
 	values.Add("metric_id", metricId)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(ep, credential, body)
+	req, err := c.buildPostReq(ep, body)
 	if err != nil {
 		return mr, httpReqError
 	}
@@ -47,7 +47,7 @@ func (c *ThreeScaleClient) CreateMappingRule(
 // "pattern"     - Mapping Rule pattern
 // "delta"       - Increase the metric by this delta
 // "metric_id"   - The metric ID
-func (c *ThreeScaleClient) UpdateMappingRule(credential string, svcId string, id string, params Params) (MappingRule, error) {
+func (c *ThreeScaleClient) UpdateMappingRule(svcId string, id string, params Params) (MappingRule, error) {
 	var m MappingRule
 
 	ep := genMrUpdateEp(svcId, id)
@@ -58,7 +58,7 @@ func (c *ThreeScaleClient) UpdateMappingRule(credential string, svcId string, id
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, credential, body)
+	req, err := c.buildUpdateReq(ep, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -76,11 +76,11 @@ func (c *ThreeScaleClient) UpdateMappingRule(credential string, svcId string, id
 
 // DeleteMappingRule - Deletes a Proxy Mapping Rule.
 // The proxy object must be updated after a mapping rule deletion to apply the change to proxy config
-func (c *ThreeScaleClient) DeleteMappingRule(credential string, svcId string, id string) error {
+func (c *ThreeScaleClient) DeleteMappingRule(svcId string, id string) error {
 	ep := genMrUpdateEp(svcId, id)
 
 	body := strings.NewReader("")
-	req, err := c.buildDeleteReq(ep, credential, body)
+	req, err := c.buildDeleteReq(ep, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -96,11 +96,11 @@ func (c *ThreeScaleClient) DeleteMappingRule(credential string, svcId string, id
 }
 
 // ListMappingRule - List API for Mapping Rule endpoint
-func (c *ThreeScaleClient) ListMappingRule(credential string, svcId string) (MappingRuleList, error) {
+func (c *ThreeScaleClient) ListMappingRule(svcId string) (MappingRuleList, error) {
 	var mrl MappingRuleList
 	ep := genMrEp(svcId)
 
-	req, err := c.buildGetReq(ep, credential)
+	req, err := c.buildGetReq(ep)
 	if err != nil {
 		return mrl, httpReqError
 	}

--- a/client/metric.go
+++ b/client/metric.go
@@ -8,13 +8,12 @@ import (
 )
 
 // CreateMetric - Creates a metric on a service. All metrics are scoped by service.
-func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name string, description string, unit string) (Metric, error) {
+func (c *ThreeScaleClient) CreateMetric(credential string, svcId string, name string, description string, unit string) (Metric, error) {
 	var m Metric
 
 	ep := genMetricCreateListEp(svcId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 	values.Add("friendly_name", name)
 	values.Add("description", description)
@@ -22,7 +21,7 @@ func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name s
 
 	body := strings.NewReader(values.Encode())
 
-	req, err := c.buildPostReq(ep, body)
+	req, err := c.buildPostReq(ep,credential, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -40,19 +39,18 @@ func (c *ThreeScaleClient) CreateMetric(accessToken string, svcId string, name s
 // "friendly_name" - Name of the metric.
 // "unit" - Measure unit of the metric.
 // "description" - Description of the metric.
-func (c *ThreeScaleClient) UpdateMetric(accessToken string, svcId string, id string, params Params) (Metric, error) {
+func (c *ThreeScaleClient) UpdateMetric(credential string, svcId string, id string, params Params) (Metric, error) {
 	var m Metric
 
 	ep := genMetricUpdateDeleteEp(svcId, id)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	for k, v := range params {
 		values.Add(k, v)
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, body)
+	req, err := c.buildUpdateReq(ep, credential, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -69,14 +67,11 @@ func (c *ThreeScaleClient) UpdateMetric(accessToken string, svcId string, id str
 
 // DeleteMetric - Deletes the metric of a service.
 // When a metric is deleted, the associated limits across application plans are removed
-func (c *ThreeScaleClient) DeleteMetric(accessToken string, svcId string, id string) error {
+func (c *ThreeScaleClient) DeleteMetric(credential string, svcId string, id string) error {
 	ep := genMetricUpdateDeleteEp(svcId, id)
 
-	values := url.Values{}
-	values.Add("access_token", accessToken)
-
-	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(ep, body)
+	body := strings.NewReader("")
+	req, err := c.buildDeleteReq(ep, credential, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -91,18 +86,17 @@ func (c *ThreeScaleClient) DeleteMetric(accessToken string, svcId string, id str
 }
 
 // ListMetric - Returns the list of metrics of a service
-func (c *ThreeScaleClient) ListMetrics(accessToken string, svcId string) (MetricList, error) {
+func (c *ThreeScaleClient) ListMetrics(credential string, svcId string) (MetricList, error) {
 	var ml MetricList
 
 	ep := genMetricCreateListEp(svcId)
 
-	req, err := c.buildGetReq(ep)
+	req, err := c.buildGetReq(ep, credential)
 	if err != nil {
 		return ml, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)

--- a/client/metric.go
+++ b/client/metric.go
@@ -8,7 +8,7 @@ import (
 )
 
 // CreateMetric - Creates a metric on a service. All metrics are scoped by service.
-func (c *ThreeScaleClient) CreateMetric(credential string, svcId string, name string, description string, unit string) (Metric, error) {
+func (c *ThreeScaleClient) CreateMetric(svcId string, name string, description string, unit string) (Metric, error) {
 	var m Metric
 
 	ep := genMetricCreateListEp(svcId)
@@ -21,7 +21,7 @@ func (c *ThreeScaleClient) CreateMetric(credential string, svcId string, name st
 
 	body := strings.NewReader(values.Encode())
 
-	req, err := c.buildPostReq(ep,credential, body)
+	req, err := c.buildPostReq(ep, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -39,7 +39,7 @@ func (c *ThreeScaleClient) CreateMetric(credential string, svcId string, name st
 // "friendly_name" - Name of the metric.
 // "unit" - Measure unit of the metric.
 // "description" - Description of the metric.
-func (c *ThreeScaleClient) UpdateMetric(credential string, svcId string, id string, params Params) (Metric, error) {
+func (c *ThreeScaleClient) UpdateMetric(svcId string, id string, params Params) (Metric, error) {
 	var m Metric
 
 	ep := genMetricUpdateDeleteEp(svcId, id)
@@ -50,7 +50,7 @@ func (c *ThreeScaleClient) UpdateMetric(credential string, svcId string, id stri
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(ep, credential, body)
+	req, err := c.buildUpdateReq(ep, body)
 	if err != nil {
 		return m, httpReqError
 	}
@@ -67,11 +67,11 @@ func (c *ThreeScaleClient) UpdateMetric(credential string, svcId string, id stri
 
 // DeleteMetric - Deletes the metric of a service.
 // When a metric is deleted, the associated limits across application plans are removed
-func (c *ThreeScaleClient) DeleteMetric(credential string, svcId string, id string) error {
+func (c *ThreeScaleClient) DeleteMetric(svcId string, id string) error {
 	ep := genMetricUpdateDeleteEp(svcId, id)
 
 	body := strings.NewReader("")
-	req, err := c.buildDeleteReq(ep, credential, body)
+	req, err := c.buildDeleteReq(ep, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -86,12 +86,12 @@ func (c *ThreeScaleClient) DeleteMetric(credential string, svcId string, id stri
 }
 
 // ListMetric - Returns the list of metrics of a service
-func (c *ThreeScaleClient) ListMetrics(credential string, svcId string) (MetricList, error) {
+func (c *ThreeScaleClient) ListMetrics(svcId string) (MetricList, error) {
 	var ml MetricList
 
 	ep := genMetricCreateListEp(svcId)
 
-	req, err := c.buildGetReq(ep, credential)
+	req, err := c.buildGetReq(ep)
 	if err != nil {
 		return ml, httpReqError
 	}

--- a/client/plan.go
+++ b/client/plan.go
@@ -16,18 +16,17 @@ const (
 )
 
 // CreateAppPlan - Creates an application plan.
-func (c *ThreeScaleClient) CreateAppPlan(accessToken string, svcId string, name string, stateEvent string) (Plan, error) {
+func (c *ThreeScaleClient) CreateAppPlan(credential string, svcId string, name string, stateEvent string) (Plan, error) {
 	var apiResp Plan
 	endpoint := fmt.Sprintf(appPlanCreate, svcId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 	values.Add("name", name)
 	values.Add("state_event", stateEvent)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, body)
+	req, err := c.buildPostReq(endpoint, credential, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}
@@ -43,11 +42,10 @@ func (c *ThreeScaleClient) CreateAppPlan(accessToken string, svcId string, name 
 }
 
 // UpdateAppPlan - Updates an application plan
-func (c *ThreeScaleClient) UpdateAppPlan(accessToken string, svcId string, appPlanId string, name string, stateEvent string, params Params) (Plan, error) {
+func (c *ThreeScaleClient) UpdateAppPlan(credential string, svcId string, appPlanId string, name string, stateEvent string, params Params) (Plan, error) {
 	endpoint := fmt.Sprintf(appPlanUpdateDelete, svcId, appPlanId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 	values.Add("name", name)
 	values.Add("state_event", stateEvent)
@@ -55,18 +53,17 @@ func (c *ThreeScaleClient) UpdateAppPlan(accessToken string, svcId string, appPl
 		values.Add(k, v)
 	}
 
-	return c.updatePlan(endpoint, accessToken, values)
+	return c.updatePlan(endpoint, credential, values)
 }
 
 // DeleteAppPlan - Deletes an application plan
-func (c *ThreeScaleClient) DeleteAppPlan(accessToken string, svcId string, appPlanId string) error {
+func (c *ThreeScaleClient) DeleteAppPlan(credential string, svcId string, appPlanId string) error {
 	endpoint := fmt.Sprintf(appPlanUpdateDelete, svcId, appPlanId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(endpoint, body)
+	req, err := c.buildDeleteReq(endpoint, credential, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -81,17 +78,16 @@ func (c *ThreeScaleClient) DeleteAppPlan(accessToken string, svcId string, appPl
 }
 
 // ListAppPlanByServiceId - Lists all application plans, filtering on service id
-func (c *ThreeScaleClient) ListAppPlanByServiceId(accessToken string, svcId string) (ApplicationPlansList, error) {
+func (c *ThreeScaleClient) ListAppPlanByServiceId(credential string, svcId string) (ApplicationPlansList, error) {
 	var appPlans ApplicationPlansList
 	endpoint := fmt.Sprintf(appPlansByServiceList, svcId)
 
-	req, err := c.buildGetReq(endpoint)
+	req, err := c.buildGetReq(endpoint, credential)
 	if err != nil {
 		return appPlans, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("service_id", svcId)
 
 	req.URL.RawQuery = values.Encode()
@@ -106,17 +102,16 @@ func (c *ThreeScaleClient) ListAppPlanByServiceId(accessToken string, svcId stri
 }
 
 // ListAppPlan - List all application plans
-func (c *ThreeScaleClient) ListAppPlan(accessToken string) (ApplicationPlansList, error) {
+func (c *ThreeScaleClient) ListAppPlan(credential string) (ApplicationPlansList, error) {
 	var appPlans ApplicationPlansList
 	endpoint := appPlansList
 
-	req, err := c.buildGetReq(endpoint)
+	req, err := c.buildGetReq(endpoint, credential)
 	if err != nil {
 		return appPlans, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 
 	req.URL.RawQuery = values.Encode()
 	resp, err := c.httpClient.Do(req)
@@ -130,18 +125,17 @@ func (c *ThreeScaleClient) ListAppPlan(accessToken string) (ApplicationPlansList
 }
 
 // SetDefaultPlan - Makes the application plan the default one
-func (c *ThreeScaleClient) SetDefaultPlan(accessToken string, svcId string, id string) (Plan, error) {
+func (c *ThreeScaleClient) SetDefaultPlan(credential string, svcId string, id string) (Plan, error) {
 	endpoint := fmt.Sprintf(appPlanSetDefault, svcId, id)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
-	return c.updatePlan(endpoint, accessToken, values)
+	return c.updatePlan(endpoint, credential, values)
 }
 
-func (c *ThreeScaleClient) updatePlan(endpoint string, accessToken string, values url.Values) (Plan, error) {
+func (c *ThreeScaleClient) updatePlan(endpoint string, credential string, values url.Values) (Plan, error) {
 	var apiResp Plan
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPutReq(endpoint, body)
+	req, err := c.buildPutReq(endpoint, credential, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}

--- a/client/plan.go
+++ b/client/plan.go
@@ -16,7 +16,7 @@ const (
 )
 
 // CreateAppPlan - Creates an application plan.
-func (c *ThreeScaleClient) CreateAppPlan(credential string, svcId string, name string, stateEvent string) (Plan, error) {
+func (c *ThreeScaleClient) CreateAppPlan(svcId string, name string, stateEvent string) (Plan, error) {
 	var apiResp Plan
 	endpoint := fmt.Sprintf(appPlanCreate, svcId)
 
@@ -26,7 +26,7 @@ func (c *ThreeScaleClient) CreateAppPlan(credential string, svcId string, name s
 	values.Add("state_event", stateEvent)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, credential, body)
+	req, err := c.buildPostReq(endpoint, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}
@@ -42,7 +42,7 @@ func (c *ThreeScaleClient) CreateAppPlan(credential string, svcId string, name s
 }
 
 // UpdateAppPlan - Updates an application plan
-func (c *ThreeScaleClient) UpdateAppPlan(credential string, svcId string, appPlanId string, name string, stateEvent string, params Params) (Plan, error) {
+func (c *ThreeScaleClient) UpdateAppPlan(svcId string, appPlanId string, name string, stateEvent string, params Params) (Plan, error) {
 	endpoint := fmt.Sprintf(appPlanUpdateDelete, svcId, appPlanId)
 
 	values := url.Values{}
@@ -53,17 +53,17 @@ func (c *ThreeScaleClient) UpdateAppPlan(credential string, svcId string, appPla
 		values.Add(k, v)
 	}
 
-	return c.updatePlan(endpoint, credential, values)
+	return c.updatePlan(endpoint, values)
 }
 
 // DeleteAppPlan - Deletes an application plan
-func (c *ThreeScaleClient) DeleteAppPlan(credential string, svcId string, appPlanId string) error {
+func (c *ThreeScaleClient) DeleteAppPlan(svcId string, appPlanId string) error {
 	endpoint := fmt.Sprintf(appPlanUpdateDelete, svcId, appPlanId)
 
 	values := url.Values{}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(endpoint, credential, body)
+	req, err := c.buildDeleteReq(endpoint, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -78,11 +78,11 @@ func (c *ThreeScaleClient) DeleteAppPlan(credential string, svcId string, appPla
 }
 
 // ListAppPlanByServiceId - Lists all application plans, filtering on service id
-func (c *ThreeScaleClient) ListAppPlanByServiceId(credential string, svcId string) (ApplicationPlansList, error) {
+func (c *ThreeScaleClient) ListAppPlanByServiceId(svcId string) (ApplicationPlansList, error) {
 	var appPlans ApplicationPlansList
 	endpoint := fmt.Sprintf(appPlansByServiceList, svcId)
 
-	req, err := c.buildGetReq(endpoint, credential)
+	req, err := c.buildGetReq(endpoint)
 	if err != nil {
 		return appPlans, httpReqError
 	}
@@ -102,11 +102,11 @@ func (c *ThreeScaleClient) ListAppPlanByServiceId(credential string, svcId strin
 }
 
 // ListAppPlan - List all application plans
-func (c *ThreeScaleClient) ListAppPlan(credential string) (ApplicationPlansList, error) {
+func (c *ThreeScaleClient) ListAppPlan() (ApplicationPlansList, error) {
 	var appPlans ApplicationPlansList
 	endpoint := appPlansList
 
-	req, err := c.buildGetReq(endpoint, credential)
+	req, err := c.buildGetReq(endpoint)
 	if err != nil {
 		return appPlans, httpReqError
 	}
@@ -125,17 +125,17 @@ func (c *ThreeScaleClient) ListAppPlan(credential string) (ApplicationPlansList,
 }
 
 // SetDefaultPlan - Makes the application plan the default one
-func (c *ThreeScaleClient) SetDefaultPlan(credential string, svcId string, id string) (Plan, error) {
+func (c *ThreeScaleClient) SetDefaultPlan(svcId string, id string) (Plan, error) {
 	endpoint := fmt.Sprintf(appPlanSetDefault, svcId, id)
 
 	values := url.Values{}
-	return c.updatePlan(endpoint, credential, values)
+	return c.updatePlan(endpoint, values)
 }
 
-func (c *ThreeScaleClient) updatePlan(endpoint string, credential string, values url.Values) (Plan, error) {
+func (c *ThreeScaleClient) updatePlan(endpoint string, values url.Values) (Plan, error) {
 	var apiResp Plan
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPutReq(endpoint, credential, body)
+	req, err := c.buildPutReq(endpoint, body)
 	if err != nil {
 		return apiResp, httpReqError
 	}

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -16,11 +16,11 @@ const (
 )
 
 // ReadProxy - Returns the Proxy for a specific Service.
-func (c *ThreeScaleClient) ReadProxy(credential string, svcID string) (Proxy, error) {
+func (c *ThreeScaleClient) ReadProxy(svcID string) (Proxy, error) {
 	var p Proxy
 
 	endpoint := fmt.Sprintf(proxyGetUpdate, svcID)
-	req, err := c.buildGetReq(endpoint, credential)
+	req, err := c.buildGetReq(endpoint)
 	if err != nil {
 		return p, httpReqError
 	}
@@ -40,20 +40,20 @@ func (c *ThreeScaleClient) ReadProxy(credential string, svcID string) (Proxy, er
 }
 
 // GetProxyConfig - Returns the Proxy Configs of a Service
-func (c *ThreeScaleClient) GetProxyConfig(credential string, svcId string, env string, version string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) GetProxyConfig(svcId string, env string, version string) (ProxyConfigElement, error) {
 	endpoint := fmt.Sprintf(proxyConfigGet, svcId, env, version)
-	return c.getProxyConfig(credential, endpoint)
+	return c.getProxyConfig(endpoint)
 }
 
 // GetLatestProxyConfig - Returns the latest Proxy Config
-func (c *ThreeScaleClient) GetLatestProxyConfig(credential string, svcId string, env string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) GetLatestProxyConfig(svcId string, env string) (ProxyConfigElement, error) {
 	endpoint := fmt.Sprintf(proxyConfigLatestGet, svcId, env)
-	return c.getProxyConfig(credential, endpoint)
+	return c.getProxyConfig(endpoint)
 }
 
 // UpdateProxy - Changes the Proxy settings.
 // This will create a new APIcast configuration version for the Staging environment with the updated settings.
-func (c *ThreeScaleClient) UpdateProxy(credential string, svcId string, params Params) (Proxy, error) {
+func (c *ThreeScaleClient) UpdateProxy(svcId string, params Params) (Proxy, error) {
 	var p Proxy
 
 	endpoint := fmt.Sprintf(proxyGetUpdate, svcId)
@@ -64,7 +64,7 @@ func (c *ThreeScaleClient) UpdateProxy(credential string, svcId string, params P
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, credential, body)
+	req, err := c.buildUpdateReq(endpoint, body)
 	if err != nil {
 		return p, httpReqError
 	}
@@ -82,11 +82,11 @@ func (c *ThreeScaleClient) UpdateProxy(credential string, svcId string, params P
 
 // ListProxyConfig - Returns the Proxy Configs of a Service
 // env parameter should be one of 'sandbox', 'production'
-func (c *ThreeScaleClient) ListProxyConfig(credential string, svcId string, env string) (ProxyConfigList, error) {
+func (c *ThreeScaleClient) ListProxyConfig(svcId string, env string) (ProxyConfigList, error) {
 	var pc ProxyConfigList
 
 	endpoint := fmt.Sprintf(proxyConfigList, svcId, env)
-	req, err := c.buildGetReq(endpoint, credential)
+	req, err := c.buildGetReq(endpoint)
 	if err != nil {
 		return pc, httpReqError
 	}
@@ -107,7 +107,7 @@ func (c *ThreeScaleClient) ListProxyConfig(credential string, svcId string, env 
 }
 
 // PromoteProxyConfig - Promotes a Proxy Config from one environment to another environment.
-func (c *ThreeScaleClient) PromoteProxyConfig(credential string, svcId string, env string, version string, toEnv string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) PromoteProxyConfig(svcId string, env string, version string, toEnv string) (ProxyConfigElement, error) {
 	var pe ProxyConfigElement
 	endpoint := fmt.Sprintf(proxyConfigPromote, svcId, env, version)
 
@@ -115,7 +115,7 @@ func (c *ThreeScaleClient) PromoteProxyConfig(credential string, svcId string, e
 	values.Add("to", toEnv)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, credential, body)
+	req, err := c.buildPostReq(endpoint, body)
 	if err != nil {
 		return pe, httpReqError
 	}
@@ -131,9 +131,9 @@ func (c *ThreeScaleClient) PromoteProxyConfig(credential string, svcId string, e
 	return pe, err
 }
 
-func (c *ThreeScaleClient) getProxyConfig(credential, endpoint string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) getProxyConfig(endpoint string) (ProxyConfigElement, error) {
 	var pc ProxyConfigElement
-	req, err := c.buildGetReq(endpoint, credential)
+	req, err := c.buildGetReq(endpoint)
 	if err != nil {
 		return pc, httpReqError
 	}

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -16,17 +16,16 @@ const (
 )
 
 // ReadProxy - Returns the Proxy for a specific Service.
-func (c *ThreeScaleClient) ReadProxy(accessToken string, svcID string) (Proxy, error) {
+func (c *ThreeScaleClient) ReadProxy(credential string, svcID string) (Proxy, error) {
 	var p Proxy
 
 	endpoint := fmt.Sprintf(proxyGetUpdate, svcID)
-	req, err := c.buildGetReq(endpoint)
+	req, err := c.buildGetReq(endpoint, credential)
 	if err != nil {
 		return p, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)
@@ -41,32 +40,31 @@ func (c *ThreeScaleClient) ReadProxy(accessToken string, svcID string) (Proxy, e
 }
 
 // GetProxyConfig - Returns the Proxy Configs of a Service
-func (c *ThreeScaleClient) GetProxyConfig(accessToken string, svcId string, env string, version string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) GetProxyConfig(credential string, svcId string, env string, version string) (ProxyConfigElement, error) {
 	endpoint := fmt.Sprintf(proxyConfigGet, svcId, env, version)
-	return c.getProxyConfig(accessToken, endpoint)
+	return c.getProxyConfig(credential, endpoint)
 }
 
 // GetLatestProxyConfig - Returns the latest Proxy Config
-func (c *ThreeScaleClient) GetLatestProxyConfig(accessToken string, svcId string, env string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) GetLatestProxyConfig(credential string, svcId string, env string) (ProxyConfigElement, error) {
 	endpoint := fmt.Sprintf(proxyConfigLatestGet, svcId, env)
-	return c.getProxyConfig(accessToken, endpoint)
+	return c.getProxyConfig(credential, endpoint)
 }
 
 // UpdateProxy - Changes the Proxy settings.
 // This will create a new APIcast configuration version for the Staging environment with the updated settings.
-func (c *ThreeScaleClient) UpdateProxy(accessToken string, svcId string, params Params) (Proxy, error) {
+func (c *ThreeScaleClient) UpdateProxy(credential string, svcId string, params Params) (Proxy, error) {
 	var p Proxy
 
 	endpoint := fmt.Sprintf(proxyGetUpdate, svcId)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	for k, v := range params {
 		values.Add(k, v)
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, body)
+	req, err := c.buildUpdateReq(endpoint, credential, body)
 	if err != nil {
 		return p, httpReqError
 	}
@@ -84,18 +82,17 @@ func (c *ThreeScaleClient) UpdateProxy(accessToken string, svcId string, params 
 
 // ListProxyConfig - Returns the Proxy Configs of a Service
 // env parameter should be one of 'sandbox', 'production'
-func (c *ThreeScaleClient) ListProxyConfig(accessToken string, svcId string, env string) (ProxyConfigList, error) {
+func (c *ThreeScaleClient) ListProxyConfig(credential string, svcId string, env string) (ProxyConfigList, error) {
 	var pc ProxyConfigList
 
 	endpoint := fmt.Sprintf(proxyConfigList, svcId, env)
-	req, err := c.buildGetReq(endpoint)
+	req, err := c.buildGetReq(endpoint, credential)
 	if err != nil {
 		return pc, httpReqError
 	}
 	req.Header.Set("Accept", "application/json")
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)
@@ -110,16 +107,15 @@ func (c *ThreeScaleClient) ListProxyConfig(accessToken string, svcId string, env
 }
 
 // PromoteProxyConfig - Promotes a Proxy Config from one environment to another environment.
-func (c *ThreeScaleClient) PromoteProxyConfig(accessToken string, svcId string, env string, version string, toEnv string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) PromoteProxyConfig(credential string, svcId string, env string, version string, toEnv string) (ProxyConfigElement, error) {
 	var pe ProxyConfigElement
 	endpoint := fmt.Sprintf(proxyConfigPromote, svcId, env, version)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("to", toEnv)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, body)
+	req, err := c.buildPostReq(endpoint, credential, body)
 	if err != nil {
 		return pe, httpReqError
 	}
@@ -135,15 +131,14 @@ func (c *ThreeScaleClient) PromoteProxyConfig(accessToken string, svcId string, 
 	return pe, err
 }
 
-func (c *ThreeScaleClient) getProxyConfig(token, endpoint string) (ProxyConfigElement, error) {
+func (c *ThreeScaleClient) getProxyConfig(credential, endpoint string) (ProxyConfigElement, error) {
 	var pc ProxyConfigElement
-	req, err := c.buildGetReq(endpoint)
+	req, err := c.buildGetReq(endpoint, credential)
 	if err != nil {
 		return pc, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", token)
 	req.URL.RawQuery = values.Encode()
 	req.Header.Set("accept", "application/json")
 

--- a/client/services.go
+++ b/client/services.go
@@ -12,17 +12,16 @@ const (
 	serviceUpdateDelete = "/admin/api/services/%s.xml"
 )
 
-func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Service, error) {
+func (c *ThreeScaleClient) CreateService(credential string, name string) (Service, error) {
 	var s Service
 
 	endpoint := serviceCreateList
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("name", name)
 	values.Add("system_name", name)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, body)
+	req, err := c.buildPostReq(endpoint, credential, body)
 	if err != nil {
 		return s, httpReqError
 	}
@@ -45,19 +44,18 @@ func (c *ThreeScaleClient) CreateService(accessToken string, name string) (Servi
 // "admin_support_email" - New admin support email.
 // "deployment_option"   - Deployment option for the gateway: 'hosted' for APIcast hosted, 'self-managed' for APIcast Self-managed option
 // "backend_version"     - Authentication mode: '1' for API key, '2' for App Id / App Key, 'oauth' for OAuth mode, 'oidc' for OpenID Connect
-func (c *ThreeScaleClient) UpdateService(accessToken string, id string, params Params) (Service, error) {
+func (c *ThreeScaleClient) UpdateService(credential string, id string, params Params) (Service, error) {
 	var s Service
 
 	endpoint := fmt.Sprintf(serviceUpdateDelete, id)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	for k, v := range params {
 		values.Add(k, v)
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, body)
+	req, err := c.buildUpdateReq(endpoint, credential, body)
 	if err != nil {
 		return s, httpReqError
 	}
@@ -74,14 +72,13 @@ func (c *ThreeScaleClient) UpdateService(accessToken string, id string, params P
 
 // DeleteService - Delete the service.
 // Deleting a service removes all applications and service subscriptions.
-func (c *ThreeScaleClient) DeleteService(accessToken string, id string) error {
+func (c *ThreeScaleClient) DeleteService(credential string, id string) error {
 	endpoint := fmt.Sprintf(serviceUpdateDelete, id)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(endpoint, body)
+	req, err := c.buildDeleteReq(endpoint, credential, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -95,18 +92,17 @@ func (c *ThreeScaleClient) DeleteService(accessToken string, id string) error {
 	return handleXMLResp(resp, http.StatusOK, nil)
 }
 
-func (c *ThreeScaleClient) ListServices(accessToken string) (ServiceList, error) {
+func (c *ThreeScaleClient) ListServices(credential string) (ServiceList, error) {
 	var sl ServiceList
 
 	ep := serviceCreateList
 
-	req, err := c.buildGetReq(ep)
+	req, err := c.buildGetReq(ep, credential)
 	if err != nil {
 		return sl, httpReqError
 	}
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)

--- a/client/services.go
+++ b/client/services.go
@@ -12,7 +12,7 @@ const (
 	serviceUpdateDelete = "/admin/api/services/%s.xml"
 )
 
-func (c *ThreeScaleClient) CreateService(credential string, name string) (Service, error) {
+func (c *ThreeScaleClient) CreateService(name string) (Service, error) {
 	var s Service
 
 	endpoint := serviceCreateList
@@ -21,7 +21,7 @@ func (c *ThreeScaleClient) CreateService(credential string, name string) (Servic
 	values.Add("system_name", name)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(endpoint, credential, body)
+	req, err := c.buildPostReq(endpoint, body)
 	if err != nil {
 		return s, httpReqError
 	}
@@ -44,7 +44,7 @@ func (c *ThreeScaleClient) CreateService(credential string, name string) (Servic
 // "admin_support_email" - New admin support email.
 // "deployment_option"   - Deployment option for the gateway: 'hosted' for APIcast hosted, 'self-managed' for APIcast Self-managed option
 // "backend_version"     - Authentication mode: '1' for API key, '2' for App Id / App Key, 'oauth' for OAuth mode, 'oidc' for OpenID Connect
-func (c *ThreeScaleClient) UpdateService(credential string, id string, params Params) (Service, error) {
+func (c *ThreeScaleClient) UpdateService(id string, params Params) (Service, error) {
 	var s Service
 
 	endpoint := fmt.Sprintf(serviceUpdateDelete, id)
@@ -55,7 +55,7 @@ func (c *ThreeScaleClient) UpdateService(credential string, id string, params Pa
 	}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, credential, body)
+	req, err := c.buildUpdateReq(endpoint, body)
 	if err != nil {
 		return s, httpReqError
 	}
@@ -72,13 +72,13 @@ func (c *ThreeScaleClient) UpdateService(credential string, id string, params Pa
 
 // DeleteService - Delete the service.
 // Deleting a service removes all applications and service subscriptions.
-func (c *ThreeScaleClient) DeleteService(credential string, id string) error {
+func (c *ThreeScaleClient) DeleteService(id string) error {
 	endpoint := fmt.Sprintf(serviceUpdateDelete, id)
 
 	values := url.Values{}
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildDeleteReq(endpoint, credential, body)
+	req, err := c.buildDeleteReq(endpoint, body)
 	if err != nil {
 		return httpReqError
 	}
@@ -92,12 +92,12 @@ func (c *ThreeScaleClient) DeleteService(credential string, id string) error {
 	return handleXMLResp(resp, http.StatusOK, nil)
 }
 
-func (c *ThreeScaleClient) ListServices(credential string) (ServiceList, error) {
+func (c *ThreeScaleClient) ListServices() (ServiceList, error) {
 	var sl ServiceList
 
 	ep := serviceCreateList
 
-	req, err := c.buildGetReq(ep, credential)
+	req, err := c.buildGetReq(ep)
 	if err != nil {
 		return sl, httpReqError
 	}

--- a/client/tenants.go
+++ b/client/tenants.go
@@ -11,7 +11,7 @@ const (
 )
 
 // CreateTenant creates new tenant using 3scale API
-func (c *ThreeScaleClient) CreateTenant(credential, orgName, username, email, password string) (*Signup, error) {
+func (c *ThreeScaleClient) CreateTenant(orgName, username, email, password string) (*Signup, error) {
 	values := url.Values{}
 	values.Add("org_name", orgName)
 	values.Add("username", username)
@@ -19,7 +19,7 @@ func (c *ThreeScaleClient) CreateTenant(credential, orgName, username, email, pa
 	values.Add("password", password)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(tenantCreate, credential, body)
+	req, err := c.buildPostReq(tenantCreate, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/tenants.go
+++ b/client/tenants.go
@@ -11,16 +11,15 @@ const (
 )
 
 // CreateTenant creates new tenant using 3scale API
-func (c *ThreeScaleClient) CreateTenant(accessToken, orgName, username, email, password string) (*Signup, error) {
+func (c *ThreeScaleClient) CreateTenant(credential, orgName, username, email, password string) (*Signup, error) {
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	values.Add("org_name", orgName)
 	values.Add("username", username)
 	values.Add("email", email)
 	values.Add("password", password)
 
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildPostReq(tenantCreate, body)
+	req, err := c.buildPostReq(tenantCreate, credential, body)
 	if err != nil {
 		return nil, err
 	}

--- a/client/tenants_test.go
+++ b/client/tenants_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestCreateTenantOk(t *testing.T) {
-	accessToken := "someAccessToken"
+	credential := "someAccessToken"
 	orgName := "someOrgName"
 	userName := "someUserName"
 	email := "someEmail@example.com"
@@ -28,7 +28,6 @@ func TestCreateTenantOk(t *testing.T) {
 			ParamName          string
 			ParamExpectedValue string
 		}{
-			{"access_token", accessToken},
 			{"org_name", orgName},
 			{"username", userName},
 			{"email", email},
@@ -51,7 +50,7 @@ func TestCreateTenantOk(t *testing.T) {
 
 	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
 
-	signup, err := c.CreateTenant(accessToken, orgName, userName, email, password)
+	signup, err := c.CreateTenant(credential, orgName, userName, email, password)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -70,7 +69,7 @@ func TestCreateTenantOk(t *testing.T) {
 }
 
 func TestCreateTenantErrors(t *testing.T) {
-	accessToken := "someAccessToken"
+	credential := "someAccessToken"
 	orgName := "someOrgName"
 	userName := "someUserName"
 	email := "someEmail@example.com"
@@ -102,7 +101,7 @@ func TestCreateTenantErrors(t *testing.T) {
 				}
 			})
 			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			_, err := c.CreateTenant(accessToken, orgName, userName, email, password)
+			_, err := c.CreateTenant(credential, orgName, userName, email, password)
 			if err == nil {
 				subTest.Fatalf("create tenant did not return error")
 			}

--- a/client/tenants_test.go
+++ b/client/tenants_test.go
@@ -48,9 +48,9 @@ func TestCreateTenantOk(t *testing.T) {
 		}
 	})
 
-	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
 
-	signup, err := c.CreateTenant(credential, orgName, userName, email, password)
+	signup, err := c.CreateTenant(orgName, userName, email, password)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -100,8 +100,8 @@ func TestCreateTenantErrors(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			})
-			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			_, err := c.CreateTenant(credential, orgName, userName, email, password)
+			c := NewThreeScale(NewTestAdminPortal(t),credential, httpClient)
+			_, err := c.CreateTenant(orgName, userName, email, password)
 			if err == nil {
 				subTest.Fatalf("create tenant did not return error")
 			}

--- a/client/types.go
+++ b/client/types.go
@@ -18,6 +18,7 @@ type AdminPortal struct {
 // ThreeScaleClient interacts with 3scale Service Management API
 type ThreeScaleClient struct {
 	adminPortal *AdminPortal
+	credential string
 	httpClient  *http.Client
 }
 

--- a/client/user.go
+++ b/client/user.go
@@ -12,12 +12,12 @@ const (
 )
 
 // ActivateUser activates user of a given account from pending state to active
-func (c *ThreeScaleClient) ActivateUser(credential, accountID, userID string) error {
+func (c *ThreeScaleClient) ActivateUser(accountID, userID string) error {
 	endpoint := fmt.Sprintf(userActivate, accountID, userID)
 
 	values := url.Values{}
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, credential, body)
+	req, err := c.buildUpdateReq(endpoint, body)
 	if err != nil {
 		return err
 	}

--- a/client/user.go
+++ b/client/user.go
@@ -12,13 +12,12 @@ const (
 )
 
 // ActivateUser activates user of a given account from pending state to active
-func (c *ThreeScaleClient) ActivateUser(accessToken, accountID, userID string) error {
+func (c *ThreeScaleClient) ActivateUser(credential, accountID, userID string) error {
 	endpoint := fmt.Sprintf(userActivate, accountID, userID)
 
 	values := url.Values{}
-	values.Add("access_token", accessToken)
 	body := strings.NewReader(values.Encode())
-	req, err := c.buildUpdateReq(endpoint, body)
+	req, err := c.buildUpdateReq(endpoint, credential, body)
 	if err != nil {
 		return err
 	}

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestActivateUserOk(t *testing.T) {
-	accessToken := "someAccessToken"
+	credential := "someAccessToken"
 	accountID := "someAccountID"
 	userID := "someUserID"
 	httpClient := NewTestClient(func(req *http.Request) *http.Response {
@@ -22,8 +22,8 @@ func TestActivateUserOk(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if req.Form.Get("access_token") != accessToken {
-			t.Fatalf("field access_token: expected (%s) found (%s)", accessToken, req.Form.Get("access_token"))
+		if req.Form.Get("access_token") != credential {
+			t.Fatalf("field access_token: expected (%s) found (%s)", credential, req.Form.Get("access_token"))
 		}
 
 		bodyReader := bytes.NewReader(helperLoadBytes(t, "user_response_fixture.xml"))
@@ -36,14 +36,14 @@ func TestActivateUserOk(t *testing.T) {
 
 	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
 
-	err := c.ActivateUser(accessToken, accountID, userID)
+	err := c.ActivateUser(credential, accountID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
 }
 
 func TestActivateUserErrors(t *testing.T) {
-	accessToken := "someAccessToken"
+	credential := "someAccessToken"
 	accountID := "someAccountID"
 	userID := "someUserID"
 	errorTests := []struct {
@@ -69,7 +69,7 @@ func TestActivateUserErrors(t *testing.T) {
 				}
 			})
 			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			err := c.ActivateUser(accessToken, accountID, userID)
+			err := c.ActivateUser(credential, accountID, userID)
 			if err == nil {
 				subTest.Fatalf("activate user did not return error")
 			}

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -22,8 +22,15 @@ func TestActivateUserOk(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if req.Form.Get("access_token") != credential {
-			t.Fatalf("field access_token: expected (%s) found (%s)", credential, req.Form.Get("access_token"))
+		auth := strings.SplitN(req.Header.Get("Authorization"), " ", 2)
+
+		if len(auth) != 2 || auth[0] != "Basic" {
+			t.Fatalf("Basic auth header missing or not valid")
+		}
+
+		expectedAuth := basicAuth("", credential)
+		if auth[1] != expectedAuth {
+			t.Fatalf("Invalid authorization header value, expected %s got %s", expectedAuth, auth[1])
 		}
 
 		bodyReader := bytes.NewReader(helperLoadBytes(t, "user_response_fixture.xml"))

--- a/client/user_test.go
+++ b/client/user_test.go
@@ -41,9 +41,9 @@ func TestActivateUserOk(t *testing.T) {
 		}
 	})
 
-	c := NewThreeScale(NewTestAdminPortal(t), httpClient)
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
 
-	err := c.ActivateUser(credential, accountID, userID)
+	err := c.ActivateUser(accountID, userID)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -75,8 +75,8 @@ func TestActivateUserErrors(t *testing.T) {
 					Header:     make(http.Header),
 				}
 			})
-			c := NewThreeScale(NewTestAdminPortal(t), httpClient)
-			err := c.ActivateUser(credential, accountID, userID)
+			c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+			err := c.ActivateUser(accountID, userID)
 			if err == nil {
 				subTest.Fatalf("activate user did not return error")
 			}


### PR DESCRIPTION
By using basic auth, we can send either access_token or provider_key as credentials
to authenticate api calls with porta.