### PR TITLE
Don't send the param state_event if empty when updating

### DIFF
--- a/client/plan.go
+++ b/client/plan.go
@@ -48,7 +48,11 @@ func (c *ThreeScaleClient) UpdateAppPlan(svcId string, appPlanId string, name st
 	values := url.Values{}
 	values.Add("service_id", svcId)
 	values.Add("name", name)
-	values.Add("state_event", stateEvent)
+
+	if stateEvent != "" {
+		values.Add("state_event", stateEvent)
+	}
+
 	for k, v := range params {
 		values.Add(k, v)
 	}


### PR DESCRIPTION
If the plan is in the state: published, and we try to send anything in the state_event param, the call will fail. 