### PR TITLE
Update the verification of raw URL string

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -110,7 +110,11 @@ func verifyUrl(urlToCheck string) (*url.URL, error) {
 	url2, err := url.ParseRequestURI(urlToCheck)
 	if err == nil {
 		if url2.Scheme != "http" && url2.Scheme != "https" {
-			err = fmt.Errorf("unsupported schema %s passed to adminPortal", url2.Scheme)
+			return url2, fmt.Errorf("unsupported schema %s passed to adminPortal", url2.Scheme)
+		}
+
+		if url2.Hostname() == "" {
+			return url2, fmt.Errorf("hostname empty after parsing")
 		}
 
 	}


### PR DESCRIPTION
The verifyUrl function uses a ParseRequestURI function from the stdlib,
however if passed a url such as '/' that function will not return an
error.

This left the possibility for a hostname (required by the client) to be
set as zero value.