### PR TITLE
product/service json endpoints

### DIFF
--- a/client/product.go
+++ b/client/product.go
@@ -1,0 +1,101 @@
+package client
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	productListResourceEndpoint = "/admin/api/services.json"
+	productResourceEndpoint     = "/admin/api/services/%d.json"
+)
+
+// CreateProduct Create 3scale Product
+func (c *ThreeScaleClient) CreateProduct(name string, params Params) (*Product, error) {
+	values := url.Values{}
+	for k, v := range params {
+		values.Add(k, v)
+	}
+	values.Add("name", name)
+
+	body := strings.NewReader(values.Encode())
+	req, err := c.buildPostReq(productListResourceEndpoint, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	product := &Product{}
+	err = handleJsonResp(resp, http.StatusCreated, product)
+	return product, err
+}
+
+// UpdateProduct Update existing product
+func (c *ThreeScaleClient) UpdateProduct(id int64, params Params) (*Product, error) {
+	values := url.Values{}
+	for k, v := range params {
+		values.Add(k, v)
+	}
+
+	putProductEndpoint := fmt.Sprintf(productResourceEndpoint, id)
+
+	body := strings.NewReader(values.Encode())
+	req, err := c.buildUpdateReq(putProductEndpoint, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	product := &Product{}
+	err = handleJsonResp(resp, http.StatusOK, product)
+	return product, err
+}
+
+// DeleteProduct Delete existing product
+func (c *ThreeScaleClient) DeleteProduct(id int64) error {
+	productEndpoint := fmt.Sprintf(productResourceEndpoint, id)
+
+	req, err := c.buildDeleteReq(productEndpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	var empty struct{}
+	return handleJsonResp(resp, http.StatusOK, &empty)
+}
+
+// ListProducts List existing products
+func (c *ThreeScaleClient) ListProducts() (*ProductList, error) {
+	req, err := c.buildGetReq(productListResourceEndpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	productList := &ProductList{}
+	err = handleJsonResp(resp, http.StatusOK, productList)
+	return productList, err
+}

--- a/client/types.go
+++ b/client/types.go
@@ -158,6 +158,8 @@ type Proxy struct {
 	OidcIssuerEndpoint      string   `xml:"oidc_issuer_endpoint"`
 }
 
+// Deprecated
+// use Product instead
 type Service struct {
 	ID                          string     `xml:"id"`
 	AccountID                   string     `xml:"account_id"`
@@ -372,4 +374,34 @@ type Signup struct {
 
 type Tenant struct {
 	Signup Signup `json:"signup"`
+}
+
+type ProductItem struct {
+	ID                        int64  `json:"id"`
+	Name                      string `json:"name"`
+	Description               string `json:"description"`
+	DeploymentOption          string `json:"deployment_option"`
+	State                     string `json:"state"`
+	SystemName                string `json:"system_name"`
+	BackendVersion            string `json:"backend_version"`
+	SupportEmail              string `json:"support_email"`
+	CreatedAt                 string `json:"created_at"`
+	UpdatedAt                 string `json:"updated_at"`
+	IntentionsRequired        bool   `json:"intentions_required"`
+	BuyersManageApps          bool   `json:"buyers_manage_apps"`
+	BuyersManageKeys          bool   `json:"buyers_manage_keys"`
+	ReferrerFiltersRequired   bool   `json:"referrer_filters_required"`
+	CustomKeysEnabled         bool   `json:"custom_keys_enabled"`
+	BuyerKeyRegenerateEnabled bool   `json:"buyer_key_regenerate_enabled"`
+	MandatoryAppKey           bool   `json:"mandatory_app_key"`
+	BuyerCanSelectPlan        bool   `json:"buyer_can_select_plan"`
+	BuyerPlanChangePermission string `json:"buyer_plan_change_permission"`
+}
+
+type Product struct {
+	Element ProductItem `json:"service"`
+}
+
+type ProductList struct {
+	Products []Product `json:"services"`
 }


### PR DESCRIPTION
* Migrate Service (new Product) to json endpoints
* Leave Services as they are for backwards compatibility but marking them as deprecated
* Fix bugs in create service. CreateService must not use `name` as `system_name`. The former is human readable string that is not unique. The latter is unique string key with format constraints to be part of urls.
  