### PR TITLE
Fix json error handling

### DIFF
--- a/client/app_test.go
+++ b/client/app_test.go
@@ -28,7 +28,7 @@ func TestCreateApp(t *testing.T) {
 		{
 			name:      "Test app creation fail",
 			returnErr: true,
-			expectErr: "error calling 3scale system - reason: error - Your access token does not have the correct permissions - code: 403",
+			expectErr: `error calling 3scale system - reason: { "error": "Your access token does not have the correct permissions" } - code: 403`,
 		},
 		{
 			name: "Test app creation success",

--- a/client/testdata/bad_request_error_response_fixture.json
+++ b/client/testdata/bad_request_error_response_fixture.json
@@ -1,0 +1,3 @@
+{
+    "error": "Test Error"
+}

--- a/client/testdata/unprocessable_error_response_fixture.json
+++ b/client/testdata/unprocessable_error_response_fixture.json
@@ -1,0 +1,3 @@
+{
+    "errors": { "system_name": ["has already been taken"] }
+}

--- a/fake/api_resp.go
+++ b/fake/api_resp.go
@@ -178,3 +178,7 @@ func GetProxyConfigLatestJson() string {
  }
 }`
 }
+
+func CreateUnprocessableEntityError() string {
+	return `{"errors":{"system_name":["has already been taken"]}}`
+}

--- a/fake/http_resp.go
+++ b/fake/http_resp.go
@@ -24,8 +24,16 @@ func CreateAppError() *http.Response {
 
 func GetProxyConfigLatestSuccess() *http.Response {
 	return &http.Response{
-		StatusCode: 200,
+		StatusCode: http.StatusOK,
 		Body:       ioutil.NopCloser(bytes.NewBufferString(GetProxyConfigLatestJson())),
+		Header:     make(http.Header),
+	}
+}
+
+func CreateStatusUnprocessableEntityError() *http.Response {
+	return &http.Response{
+		StatusCode: http.StatusUnprocessableEntity,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(CreateUnprocessableEntityError())),
 		Header:     make(http.Header),
 	}
 }


### PR DESCRIPTION
For JSON endpoints, when 3scale API returns `http.StatusUnprocessableEntity` response status code, the body contains the specific error format:
```
struct {                               
    Errors map[string][]string `json:"errors"`   
}                                              
```

For instance:

```
{"errors":{"system_name":["has already been taken"]}}
```

Current implementation was shadowing the actual error with decoding error as it was trying to parse with 
```
map[string]string
```

For the generic error response, the body is just readed and not parsed. This breaks backwards compatibility for a given set of endpoints, resulting a slightly different error message than before. For example: 
Before:
```
error calling 3scale system - reason: error - Your access token does not have the correct permissions - code: 403"
```

Now:
```
error calling 3scale system - reason: { "error": "Your access token does not have the correct permissions" } - code: 403
```

If this an inconvenience, the code may be improved to process specific cases. Which I do not think so, but asking for safety :)
