### PR TITLE
fix json response parsing when not needed

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -149,6 +149,10 @@ func handleJsonResp(resp *http.Response, expectCode int, decodeInto interface{})
 		return handleJsonErrResp(resp)
 	}
 
+	if decodeInto == nil {
+		return nil
+	}
+
 	if err := json.NewDecoder(resp.Body).Decode(decodeInto); err != nil {
 		return createApiErr(resp.StatusCode, createDecodingErrorMessage(err))
 	}

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -2,10 +2,12 @@ package client
 
 import (
 	"bytes"
-	"github.com/3scale/3scale-porta-go-client/fake"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"testing"
+
+	"github.com/3scale/3scale-porta-go-client/fake"
 )
 
 func TestNewAdminPortal(t *testing.T) {
@@ -42,6 +44,18 @@ func TestHandleJsonResp(t *testing.T) {
 		t.Fatalf("Expected error: [%s]; got [%s]", expectedErr, err.Error())
 	}
 
+}
+
+func TestHandleJsonRespNilBody(t *testing.T) {
+	emptyResp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       ioutil.NopCloser(strings.NewReader("")),
+		Header:     make(http.Header),
+	}
+	err := handleJsonResp(emptyResp, http.StatusOK, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func TestHandleJsonErrResp(mainT *testing.T) {


### PR DESCRIPTION
If the user does not want to parse response, let it be.