### PR TITLE
Adds a hook into HTTP request/response info for telemetry purposes

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -40,7 +40,11 @@ func NewThreeScale(backEnd *AdminPortal, credential string, httpClient *http.Cli
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &ThreeScaleClient{backEnd, credential, httpClient}
+	return &ThreeScaleClient{
+		adminPortal: backEnd,
+		credential:  credential,
+		httpClient:  httpClient,
+	}
 }
 
 func NewParams() Params {
@@ -55,6 +59,12 @@ func (p Params) AddParam(key string, value string) {
 // SetCredentials allow the user to set the client credentials
 func (c *ThreeScaleClient) SetCredentials(credential string) {
 	c.credential = credential
+}
+
+// SetHook sets the callback which gets invoked upon response from 3scale
+// Note, this is not supported by all endpoints, refer to endpoints documentation
+func (c *ThreeScaleClient) SetHook(cb AfterResponseCB) {
+	c.afterResponse = cb
 }
 
 // Request builder for GET request to the provided endpoint

--- a/client/types.go
+++ b/client/types.go
@@ -20,7 +20,11 @@ type ThreeScaleClient struct {
 	adminPortal *AdminPortal
 	credential  string
 	httpClient  *http.Client
+	afterResponse AfterResponseCB
 }
+
+// AfterResponseCB provides a hook that can be used to infer details of the underlying HTTP request/response
+type AfterResponseCB func(statusCode int, timeTaken time.Duration)
 
 // Application - API response for create app endpoint
 type Application struct {


### PR DESCRIPTION
@eguzki we want to make use of this in the authorizer project in order to produce metrics. This is the only API we are interested in at the moment but if its useful elsewhere we can easily add it where appropriate or refactor to support all by default.