### PR TITLE
client: Accept raw string when creating admin portal

### DIFF
--- a/client/types.go
+++ b/client/types.go
@@ -9,10 +9,8 @@ import (
 
 // AdminPortal defines a 3scale adminPortal service
 type AdminPortal struct {
-	scheme  string
-	host    string
-	port    int
-	baseUrl *url.URL
+	rawURL string
+	url    *url.URL
 }
 
 // ThreeScaleClient interacts with 3scale Service Management API


### PR DESCRIPTION
Adds constructor for instantiating an "AdminPortal" with a raw string.

This reduces some complexity in the creating of the HTTP requests
internally and also provides a Fixes #31 ensuring we can support
non-standard installs that are installed under a specific path.