### PR TITLE
Developeruser endpoints

### DIFF
--- a/client/accounts.go
+++ b/client/accounts.go
@@ -9,6 +9,7 @@ const (
 	accountList = "/admin/api/accounts.json"
 )
 
+// Deprecated: Use ListDeveloperAccounts instead
 func (c *ThreeScaleClient) ListAccounts() (*AccountList, error) {
 	req, err := c.buildGetReq(accountList)
 	if err != nil {

--- a/client/developer_users.go
+++ b/client/developer_users.go
@@ -1,0 +1,247 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+)
+
+const (
+	developerUserActivateEndpoint          = "/admin/api/accounts/%d/users/%d/activate.json"
+	developerUserListResourceEndpoint      = "/admin/api/accounts/%d/users.json"
+	developerUserResourceEndpoint          = "/admin/api/accounts/%d/users/%d.json"
+	developerUserMemberResourceEndpoint    = "/admin/api/accounts/%d/users/%d/member.json"
+	developerUserAdminResourceEndpoint     = "/admin/api/accounts/%d/users/%d/admin.json"
+	developerUserSuspendResourceEndpoint   = "/admin/api/accounts/%d/users/%d/suspend.json"
+	developerUserUnsuspendResourceEndpoint = "/admin/api/accounts/%d/users/%d/unsuspend.json"
+)
+
+func (c *ThreeScaleClient) ListDeveloperUsers(accountID int64, filterParams Params) (*DeveloperUserList, error) {
+	endpoint := fmt.Sprintf(developerUserListResourceEndpoint, accountID)
+	req, err := c.buildGetReq(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	values := url.Values{}
+	for k, v := range filterParams {
+		values.Add(k, v)
+	}
+	req.URL.RawQuery = values.Encode()
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	userList := &DeveloperUserList{}
+	err = handleJsonResp(resp, http.StatusOK, userList)
+	return userList, err
+}
+
+func (c *ThreeScaleClient) DeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserResourceEndpoint, accountID, userID)
+	req, err := c.buildGetReq(endpoint)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	obj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, obj)
+	return obj, err
+}
+
+// UpdateDeveloperUser Update existing developer user
+func (c *ThreeScaleClient) UpdateDeveloperUser(accountID int64, user *DeveloperUser) (*DeveloperUser, error) {
+	if user == nil {
+		return nil, errors.New("UpdateDeveloperUser requires not-nil DeveloperUser pointer")
+	}
+
+	if user.Element.ID == nil {
+		return nil, errors.New("UpdateDeveloperUser requires not-nil DeveloperUser ID")
+	}
+
+	endpoint := fmt.Sprintf(developerUserResourceEndpoint, accountID, *user.Element.ID)
+
+	bodyArr, err := json.Marshal(user.Element)
+	if err != nil {
+		return nil, err
+	}
+	body := bytes.NewReader(bodyArr)
+
+	req, err := c.buildUpdateJSONReq(endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}
+
+// DeleteDeveloperUser Delete existing developerUser
+func (c *ThreeScaleClient) DeleteDeveloperUser(accountID, userID int64) error {
+	endpoint := fmt.Sprintf(developerUserResourceEndpoint, accountID, userID)
+
+	req, err := c.buildDeleteReq(endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return handleJsonResp(resp, http.StatusOK, nil)
+}
+
+// ActivateDeveloperUser activates user of a given account from pending state to active
+func (c *ThreeScaleClient) ActivateDeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserActivateEndpoint, accountID, userID)
+
+	req, err := c.buildUpdateJSONReq(endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}
+
+// CreateDeveloperUser creates a new developer user
+// username and email are unique fields for the entire provider account
+// role attribute ["member", "admin"] cannot be set. All new developer users have member role
+// state attribute ["pending", "active", "suspended"] cannot be set. All new developer users are in "pending" state
+func (c *ThreeScaleClient) CreateDeveloperUser(accountID int64, user *DeveloperUser) (*DeveloperUser, error) {
+	if user == nil {
+		return nil, errors.New("CreateDeveloperUser requires not-nil DeveloperUser pointer")
+	}
+
+	endpoint := fmt.Sprintf(developerUserListResourceEndpoint, accountID)
+
+	bodyArr, err := json.Marshal(user.Element)
+	if err != nil {
+		return nil, err
+	}
+	body := bytes.NewReader(bodyArr)
+
+	req, err := c.buildPostJSONReq(endpoint, body)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusCreated, respObj)
+	return respObj, err
+}
+
+// ChangeRoleToMemberDeveloperUser sets user of a given account to member role
+func (c *ThreeScaleClient) ChangeRoleToMemberDeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserMemberResourceEndpoint, accountID, userID)
+
+	req, err := c.buildUpdateJSONReq(endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}
+
+// ChangeRoleToAdminDeveloperUser sets user of a given account to member role
+func (c *ThreeScaleClient) ChangeRoleToAdminDeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserAdminResourceEndpoint, accountID, userID)
+
+	req, err := c.buildUpdateJSONReq(endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}
+
+// SuspendDeveloperUser suspends the user of a given account
+func (c *ThreeScaleClient) SuspendDeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserSuspendResourceEndpoint, accountID, userID)
+
+	req, err := c.buildUpdateJSONReq(endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}
+
+// UnsuspendDeveloperUser unsuspends the user of a given account
+func (c *ThreeScaleClient) UnsuspendDeveloperUser(accountID, userID int64) (*DeveloperUser, error) {
+	endpoint := fmt.Sprintf(developerUserUnsuspendResourceEndpoint, accountID, userID)
+
+	req, err := c.buildUpdateJSONReq(endpoint, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	respObj := &DeveloperUser{}
+	err = handleJsonResp(resp, http.StatusOK, respObj)
+	return respObj, err
+}

--- a/client/developer_users_test.go
+++ b/client/developer_users_test.go
@@ -1,0 +1,493 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func developerUser1() DeveloperUser {
+	var userID int64 = 1
+
+	return DeveloperUser{
+		Element: DeveloperUserItem{
+			ID: &userID,
+		},
+	}
+
+}
+
+func developerUser2() DeveloperUser {
+	var userID int64 = 2
+
+	return DeveloperUser{
+		Element: DeveloperUserItem{
+			ID: &userID,
+		},
+	}
+
+}
+
+func TestListDeveloperUsers(t *testing.T) {
+	var (
+		accountID int64 = 12
+
+		endpoint = fmt.Sprintf(developerUserListResourceEndpoint, accountID)
+
+		list = DeveloperUserList{
+			Items: []DeveloperUser{
+				developerUser1(),
+				developerUser2(),
+			},
+		}
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodGet {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(list)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.ListDeveloperUsers(accountID, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, list) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(list)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodGet {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.DeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestUpdateDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.UpdateDeveloperUser(accountID, &item)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestDeleteDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserResourceEndpoint, accountID, userID)
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodDelete {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodDelete, req.Method)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader("")),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	err := c.DeleteDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestActivateDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserActivateEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.ActivateDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestCreateDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		endpoint        = fmt.Sprintf(developerUserListResourceEndpoint, accountID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPost {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPost, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.CreateDeveloperUser(accountID, &item)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestChangeRoleToMemberDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserMemberResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.ChangeRoleToMemberDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestChangeRoleToAdminDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserAdminResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.ChangeRoleToAdminDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestSuspendDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserSuspendResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.SuspendDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}
+
+func TestUnsuspendDeveloperUser(t *testing.T) {
+	var (
+		accountID int64 = 12
+		userID    int64 = 1
+		endpoint        = fmt.Sprintf(developerUserUnsuspendResourceEndpoint, accountID, userID)
+		item            = developerUser1()
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodPut {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodPut, req.Method)
+		}
+
+		responseBodyBytes, err := json.Marshal(item)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	resp, err := c.UnsuspendDeveloperUser(accountID, userID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp == nil {
+		t.Fatal("response was nil")
+	}
+
+	if !reflect.DeepEqual(*resp, item) {
+		got, _ := json.Marshal(*resp)
+		expected, _ := json.Marshal(item)
+		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	}
+}

--- a/client/types.go
+++ b/client/types.go
@@ -332,6 +332,7 @@ type ProxyRule struct {
 
 type Params map[string]string
 
+// Deprecated: Use DeveloperUser instead
 type User struct {
 	ID        int64  `json:"id"`
 	State     string `json:"state"`
@@ -340,10 +341,12 @@ type User struct {
 	AccountID int64  `json:"account_id"`
 }
 
+// Deprecated: Use DeveloperUserItem instead
 type UserElem struct {
 	User User `json:"user"`
 }
 
+// Deprecated: Use DeveloperUser instead
 type UserList struct {
 	Users []UserElem `json:"users"`
 }
@@ -741,4 +744,23 @@ type APIcastPolicy struct {
 
 type APIcastPolicyRegistry struct {
 	Items []APIcastPolicy `json:"policies"`
+}
+
+type DeveloperUserItem struct {
+	ID        *int64  `json:"id,omitempty"`
+	State     *string `json:"state,omitempty"`
+	Role      *string `json:"role,omitempty"`
+	Username  *string `json:"username,omitempty"`
+	Password  *string `json:"password,omitempty"`
+	Email     *string `json:"email,omitempty"`
+	CreatedAt *string `json:"created_at,omitempty"`
+	UpdatedAt *string `json:"updated_at,omitempty"`
+}
+
+type DeveloperUser struct {
+	Element DeveloperUserItem `json:"user"`
+}
+
+type DeveloperUserList struct {
+	Items []DeveloperUser `json:"users"`
 }

--- a/client/user.go
+++ b/client/user.go
@@ -15,6 +15,7 @@ const (
 )
 
 // ActivateUser activates user of a given account from pending state to active
+// Deprecated: Use ActivateDeveloperUser instead
 func (c *ThreeScaleClient) ActivateUser(accountID, userID int64) error {
 	endpoint := fmt.Sprintf(userActivate, accountID, userID)
 
@@ -37,6 +38,7 @@ func (c *ThreeScaleClient) ActivateUser(accountID, userID int64) error {
 }
 
 // ReadUser reads user of a given account
+// Deprecated: Use DeveloperUser instead
 func (c *ThreeScaleClient) ReadUser(accountID, userID int64) (*User, error) {
 	endpoint := fmt.Sprintf(userRead, accountID, userID)
 	req, err := c.buildGetReq(endpoint)
@@ -59,6 +61,7 @@ func (c *ThreeScaleClient) ReadUser(accountID, userID int64) (*User, error) {
 }
 
 // ListUser list users of a given account and a given filter params
+// Deprecated: Use ListDeveloperAccounts instead
 func (c *ThreeScaleClient) ListUsers(accountID int64, filterParams Params) (*UserList, error) {
 	endpoint := fmt.Sprintf(userList, accountID)
 	req, err := c.buildGetReq(endpoint)
@@ -87,6 +90,7 @@ func (c *ThreeScaleClient) ListUsers(accountID int64, filterParams Params) (*Use
 }
 
 // UpdateUser updates user of a given account
+// Deprecated: Use UpdateDeveloperUser instead
 func (c *ThreeScaleClient) UpdateUser(accountID int64, userID int64, userParams Params) (*User, error) {
 	endpoint := fmt.Sprintf(userUpdate, accountID, userID)
 


### PR DESCRIPTION
* Mark as deprecated few methods
  * ListAccounts  (in favor of DeveloperAccount list)
  * User type and endpoints  (in favor of DeveloperUser type and methods)
* New developer user methods:
  * Activate
  * Change Role to Member
  * Change Role to Admin
  * Suspend
  * Unsuspend
  * Create
  * Delete
  * Read
  * List
  * Update