### PR TITLE
Fix delete product

### DIFF
--- a/client/client_test.go
+++ b/client/client_test.go
@@ -159,7 +159,8 @@ func TestAdminPortalPathIsPreserved(t *testing.T) {
 	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services.xml")
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<services></services>`))),
 		}
 	})).ListServices()
 	if err != nil {
@@ -170,7 +171,8 @@ func TestAdminPortalPathIsPreserved(t *testing.T) {
 	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services.xml")
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
+			StatusCode: http.StatusCreated,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<service></service>`))),
 		}
 	})).CreateService("any")
 	if err != nil {
@@ -181,7 +183,8 @@ func TestAdminPortalPathIsPreserved(t *testing.T) {
 	err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services/any.xml")
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
 		}
 	})).DeleteService("any")
 	if err != nil {
@@ -192,7 +195,8 @@ func TestAdminPortalPathIsPreserved(t *testing.T) {
 	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services/any.xml")
 		return &http.Response{
-			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer([]byte(`<service></service>`))),
 		}
 	})).UpdateService("any", NewParams())
 	if err != nil {

--- a/client/client_test.go
+++ b/client/client_test.go
@@ -148,46 +148,56 @@ func TestAdminPortalPathIsPreserved(t *testing.T) {
 		t.Errorf("expected trailing slash to be stripped")
 	}
 
-	verify:= func(req *http.Request, path string) {
+	verify := func(req *http.Request, path string) {
 		equals(t, host, req.URL.Hostname())
 		equals(t, port, req.URL.Port())
 		equals(t, scheme, req.URL.Scheme)
 		equals(t, path, req.URL.Path)
 	}
 
-
 	// Test path is preserved for GET
-	NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
+	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services.xml")
 		return &http.Response{
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
 		}
 	})).ListServices()
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test path is preserved for POST
-	NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
+	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
 		verify(req, "/example/admin/api/services.xml")
 		return &http.Response{
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
 		}
 	})).CreateService("any")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test path is preserved for DELETE
-	NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
-		verify(req,"/example/admin/api/services/any.xml")
+	err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
+		verify(req, "/example/admin/api/services/any.xml")
 		return &http.Response{
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
 		}
 	})).DeleteService("any")
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	// Test path is preserved for PUT
-	NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
-		verify(req,"/example/admin/api/services/any.xml")
+	_, err = NewThreeScale(ap, "any", NewTestClient(func(req *http.Request) *http.Response {
+		verify(req, "/example/admin/api/services/any.xml")
 		return &http.Response{
 			Body: ioutil.NopCloser(bytes.NewBuffer([]byte(""))),
 		}
 	})).UpdateService("any", NewParams())
-
+	if err != nil {
+		t.Fatal(err)
+	}
 }
 
 func equals(t *testing.T, exp, act interface{}) {

--- a/client/mapping.go
+++ b/client/mapping.go
@@ -63,11 +63,11 @@ func (c *ThreeScaleClient) UpdateMappingRule(svcId string, id string, params Par
 	}
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return m, err
 	}
+
+	defer resp.Body.Close()
 
 	err = handleXMLResp(resp, http.StatusOK, &m)
 	return m, err
@@ -85,11 +85,10 @@ func (c *ThreeScaleClient) DeleteMappingRule(svcId string, id string) error {
 	}
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	return handleXMLResp(resp, http.StatusOK, nil)
 }

--- a/client/product.go
+++ b/client/product.go
@@ -106,8 +106,7 @@ func (c *ThreeScaleClient) DeleteProduct(id int64) error {
 	}
 	defer resp.Body.Close()
 
-	var empty struct{}
-	return handleJsonResp(resp, http.StatusOK, &empty)
+	return handleJsonResp(resp, http.StatusOK, nil)
 }
 
 // ListProducts List existing products

--- a/client/proxy.go
+++ b/client/proxy.go
@@ -31,11 +31,10 @@ func (c *ThreeScaleClient) ReadProxy(svcID string) (Proxy, error) {
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return p, err
 	}
+	defer resp.Body.Close()
 
 	err = handleXMLResp(resp, http.StatusOK, &p)
 	return p, err
@@ -74,11 +73,11 @@ func (c *ThreeScaleClient) UpdateProxy(svcId string, params Params) (Proxy, erro
 	}
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return p, err
 	}
+
+	defer resp.Body.Close()
 
 	err = handleXMLResp(resp, http.StatusOK, &p)
 	return p, err
@@ -100,11 +99,11 @@ func (c *ThreeScaleClient) ListProxyConfig(svcId string, env string) (ProxyConfi
 	req.URL.RawQuery = values.Encode()
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return pc, err
 	}
+
+	defer resp.Body.Close()
 
 	err = handleJsonResp(resp, http.StatusOK, &pc)
 	return pc, err
@@ -125,11 +124,11 @@ func (c *ThreeScaleClient) PromoteProxyConfig(svcId string, env string, version 
 	}
 
 	resp, err := c.httpClient.Do(req)
-	defer resp.Body.Close()
-
 	if err != nil {
 		return pe, err
 	}
+
+	defer resp.Body.Close()
 
 	err = handleJsonResp(resp, http.StatusCreated, &pe)
 	return pe, err
@@ -151,7 +150,7 @@ func (c *ThreeScaleClient) getProxyConfig(endpoint string) (ProxyConfigElement, 
 	if err != nil {
 		return pc, err
 	}
-	timeTaken := time.Now().Sub(start)
+	timeTaken := time.Since(start)
 	if c.afterResponse != nil {
 		c.afterResponse(resp.StatusCode, timeTaken)
 	}

--- a/client/testdata/product_list_fixture.json
+++ b/client/testdata/product_list_fixture.json
@@ -1,0 +1,24 @@
+{
+  "services": [
+    {
+      "service": {
+        "id": 45498,
+        "name": "Product 01",
+        "system_name": "product_01",
+        "description": "",
+        "created_at": "2019-11-29T17:18:02+01:00",
+        "updated_at": "2020-03-25T15:07:22+01:00"
+      }
+    },
+    {
+      "service": {
+        "id": 55498,
+        "name": "Product 02",
+        "system_name": "product_02",
+        "description": "",
+        "created_at": "2019-11-29T17:18:02+01:00",
+        "updated_at": "2020-03-25T15:07:22+01:00"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
### What

1. Fix `DeleteProduct`
`DeleteProduct" method was returning error even when the 3scale API returned `200 OK`. The error

```
error calling 3scale system - reason: decoding error - EOF - code: 200
```
2.  Added unittests
* CreateProduct
* UpdateProduct
* DeleteProduct
* ListProducts

3. Fixed lint issues

### Verification Steps

Delete a product, the method should not return error

```go
adminPortalURL := "https://3scale-admin.example.com"
threescaleAccessToken := "************************"

adminPortal, err := client.NewAdminPortalFromStr(adminPortalURL)
if err != nil {
   fmt.Printf("%+v\n", err)
	return
}
threescaleClient := client.NewThreeScale(adminPortal, threescaleAccessToken, nil)
err := threescaleClient.DeleteProduct(1234565) // err should not be nil when the product exists
```
