### PR TITLE
account proxy endpoint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: circleci/golang:1.13.7
+      - image: cimg/go:1.19.4
     steps:
       - checkout
       - run:

--- a/Makefile
+++ b/Makefile
@@ -3,12 +3,6 @@ PACKAGE_CLIENT = github.com/3scale/3scale-porta-go-client/client
 MKFILE_PATH := $(abspath $(lastword $(MAKEFILE_LIST)))
 PROJECT_PATH := $(patsubst %/,%,$(dir $(MKFILE_PATH)))
 
-# find or download gotest
-# download gotest if necessary
-GOTEST=$(PROJECT_PATH)/bin/gotest
-$(GOTEST):
-	$(call go-get-tool,$(GOTEST),github.com/rakyll/gotest)
-
 .DEFAULT_GOAL := help
 .PHONY : help
 help: Makefile
@@ -16,18 +10,8 @@ help: Makefile
 
 ## test: Run unit tests
 .PHONY: test
-test: $(GOTEST)
-	$(GOTEST) -v $(PACKAGE_CLIENT) -test.coverprofile="coverage.txt"
-
-# go-get-tool will 'go get' any package $2 and install it to $1.
-define go-get-tool
-@[ -f $(1) ] || { \
-set -e ;\
-TMP_DIR=$$(mktemp -d) ;\
-cd $$TMP_DIR ;\
-go mod init tmp ;\
-echo "Downloading $(2)" ;\
-GOBIN=$(PROJECT_PATH)/bin go get $(2) ;\
-rm -rf $$TMP_DIR ;\
-}
-endef
+ifdef TEST_NAME
+test: TEST_PATTERN := --run $(TEST_NAME)
+endif
+test:
+	go test -v $(PACKAGE_CLIENT) -test.coverprofile="coverage.txt" $(TEST_PATTERN)

--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ threescaleClient := client.NewThreeScale(adminPortal, threescaleAccessToken, &ht
 $ make test
 ```
 
+Optionally, add `TEST_NAME` makefile variable to run specific test
+
+```sh
+make test TEST_NAME=TestActivateUserErrors
+```
+
+or even subtest
+
+```sh
+make test TEST_NAME=TestActivateUserErrors/UnexpectedHTTPStatusCode
+```
+
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub](https://github.com/3scale/3scale-porta-go-client)

--- a/client/app.go
+++ b/client/app.go
@@ -242,7 +242,7 @@ func (c *ThreeScaleClient) Application(accountId, id int64) (*Application, error
 }
 
 func (c *ThreeScaleClient) ListAllApplications() (*ApplicationList, error) {
-	endpoint := fmt.Sprintf(listAllApplications)
+	endpoint := listAllApplications
 
 	req, err := c.buildGetJSONReq(endpoint)
 	if err != nil {

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -598,7 +598,7 @@ func TestListAllApplications(t *testing.T) {
 				t.Fatalf("wrong helper called")
 			}
 
-			if req.URL.Path != fmt.Sprintf(listAllApplications) {
+			if req.URL.Path != listAllApplications {
 				t.Fatalf("wrong url generated")
 			}
 

--- a/client/proxy_test.go
+++ b/client/proxy_test.go
@@ -1,0 +1,233 @@
+package client
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"testing"
+)
+
+func TestListAccountProxyConfigsParams(t *testing.T) {
+	var (
+		env        string = "production"
+		endpoint   string = fmt.Sprintf(accountProxyConfigGet, env)
+		credential string = "someAccessToken"
+	)
+
+	errorTests := []struct {
+		Name             string
+		version          *string
+		host             *string
+		expectedRawQuery string
+	}{
+		{"no version or host", nil, nil, ""},
+		{"only version", &[]string{"latest"}[0], nil, "version=latest"},
+		{"only host", nil, &[]string{"example.com"}[0], "host=example.com"},
+		{"version and host set", &[]string{"latest"}[0], &[]string{"example.com"}[0], "host=example.com&version=latest"},
+	}
+
+	for _, tt := range errorTests {
+		t.Run(tt.Name, func(subT *testing.T) {
+			httpClient := NewTestClient(func(req *http.Request) *http.Response {
+				if req.URL.Path != endpoint {
+					subT.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+				}
+
+				if req.URL.RawQuery != tt.expectedRawQuery {
+					subT.Fatalf("RawPath does not match. Expected [%s]; got [%s]", tt.expectedRawQuery, req.URL.RawQuery)
+				}
+
+				if req.Method != http.MethodGet {
+					subT.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+				}
+
+				return &http.Response{
+					StatusCode: http.StatusOK,
+					Body:       ioutil.NopCloser(bytes.NewReader(helperLoadBytes(subT, "account_proxy_fixture.json"))),
+					Header:     make(http.Header),
+				}
+			})
+
+			c := NewThreeScale(NewTestAdminPortal(subT), credential, httpClient)
+			proxyConfigList, err := c.ListAccountProxyConfigsPerPage(env, tt.version, tt.host)
+			if err != nil {
+				subT.Fatal(err)
+			}
+
+			if proxyConfigList.ProxyConfigs == nil {
+				subT.Fatal("backend list returned nil")
+			}
+
+			if len(proxyConfigList.ProxyConfigs) != 1 {
+				subT.Fatalf("Then number of proxy_configs does not match. Expected [%d]; got [%d]", 1, len(proxyConfigList.ProxyConfigs))
+			}
+		})
+	}
+}
+
+func TestListAccountProxyConfigsPagination(t *testing.T) {
+	configGenerator := func(startingIndex, n int) ProxyConfigList {
+		pList := ProxyConfigList{
+			ProxyConfigs: make([]ProxyConfigElement, 0, n),
+		}
+
+		for idx := 0; idx < n; idx++ {
+			pList.ProxyConfigs = append(pList.ProxyConfigs, ProxyConfigElement{
+				ProxyConfig: ProxyConfig{ID: idx + startingIndex},
+			})
+		}
+
+		return pList
+	}
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		// Will serve: 3 pages
+		// page 1 => PROXYCONFIGS_PER_PAGE
+		// page 2 => PROXYCONFIGS_PER_PAGE
+		// page 3 => 51
+		if req.URL.Path != fmt.Sprintf(accountProxyConfigGet, "production") {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", accountProxyConfigGet, req.URL.Path)
+		}
+
+		if req.Method != http.MethodGet {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+		}
+
+		if req.URL.Query().Get("per_page") != strconv.Itoa(PROXYCONFIGS_PER_PAGE) {
+			t.Fatalf("per_page param does not match. Expected [%d]; got [%s]", PROXYCONFIGS_PER_PAGE, req.URL.Query().Get("per_page"))
+		}
+
+		var list ProxyConfigList
+
+		if req.URL.Query().Get("page") == "1" {
+			list = configGenerator(PROXYCONFIGS_PER_PAGE*0, PROXYCONFIGS_PER_PAGE)
+		} else if req.URL.Query().Get("page") == "2" {
+			list = configGenerator(PROXYCONFIGS_PER_PAGE*1, PROXYCONFIGS_PER_PAGE)
+		} else if req.URL.Query().Get("page") == "3" {
+			list = configGenerator(PROXYCONFIGS_PER_PAGE*2, 51)
+		} else {
+			t.Fatalf("page param unexpected value; got [%s]", req.URL.Query().Get("page"))
+		}
+
+		responseBodyBytes, err := json.Marshal(list)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	pList, err := c.ListAccountProxyConfigs("production", nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if pList == nil {
+		t.Fatal("configlist returned nil")
+	}
+
+	if len(pList.ProxyConfigs) != 2*PROXYCONFIGS_PER_PAGE+51 {
+		t.Fatalf("Then number of proxy configs does not match. Expected [%d]; got [%d]", 2*PROXYCONFIGS_PER_PAGE+51, len(pList.ProxyConfigs))
+	}
+}
+
+func TestListAccountProxyConfigsPerPage(t *testing.T) {
+	var (
+		env string = "production"
+	)
+	t.Run("page and per_page params used", func(subT *testing.T) {
+		var (
+			pageNum int = 4
+			perPage int = 1
+		)
+
+		httpClient := NewTestClient(func(req *http.Request) *http.Response {
+			if req.URL.Path != fmt.Sprintf(accountProxyConfigGet, env) {
+				subT.Fatalf("Path does not match. Expected [%s]; got [%s]", fmt.Sprintf(accountProxyConfigGet, env), req.URL.Path)
+			}
+
+			if req.Method != http.MethodGet {
+				subT.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+			}
+
+			if req.URL.Query().Get("page") != strconv.Itoa(pageNum) {
+				subT.Fatalf("page param does not match. Expected [%d]; got [%s]", pageNum, req.URL.Query().Get("page"))
+			}
+
+			if req.URL.Query().Get("per_page") != strconv.Itoa(perPage) {
+				subT.Fatalf("page param does not match. Expected [%d]; got [%s]", perPage, req.URL.Query().Get("per_page"))
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(helperLoadBytes(subT, "account_proxy_fixture.json"))),
+				Header:     make(http.Header),
+			}
+		})
+
+		credential := "someAccessToken"
+		c := NewThreeScale(NewTestAdminPortal(subT), credential, httpClient)
+		pList, err := c.ListAccountProxyConfigsPerPage(env, nil, nil, pageNum, perPage)
+		if err != nil {
+			subT.Fatal(err)
+		}
+
+		if pList == nil {
+			subT.Fatal("config list returned nil")
+		}
+
+		if len(pList.ProxyConfigs) != 1 {
+			subT.Fatalf("Then number of proxy configs does not match. Expected [%d]; got [%d]", 2, len(pList.ProxyConfigs))
+		}
+	})
+
+	t.Run("page and per_page params not used", func(subT *testing.T) {
+		httpClient := NewTestClient(func(req *http.Request) *http.Response {
+			if req.URL.Path != fmt.Sprintf(accountProxyConfigGet, "production") {
+				subT.Fatalf("Path does not match. Expected [%s]; got [%s]", fmt.Sprintf(accountProxyConfigGet, "production"), req.URL.Path)
+			}
+
+			if req.Method != http.MethodGet {
+				subT.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+			}
+
+			if req.URL.Query().Get("page") != "" {
+				subT.Fatalf("Query param page does not match. Expected empty; got [%s]", req.URL.Query().Get("page"))
+			}
+
+			if req.URL.Query().Get("per_page") != "" {
+				subT.Fatalf("page param does not match. Expected empty; got [%s]", req.URL.Query().Get("per_page"))
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewReader(helperLoadBytes(subT, "account_proxy_fixture.json"))),
+				Header:     make(http.Header),
+			}
+		})
+
+		credential := "someAccessToken"
+		c := NewThreeScale(NewTestAdminPortal(subT), credential, httpClient)
+		pList, err := c.ListAccountProxyConfigsPerPage(env, nil, nil)
+		if err != nil {
+			subT.Fatal(err)
+		}
+
+		if pList == nil {
+			subT.Fatal("configslist returned nil")
+		}
+
+		if len(pList.ProxyConfigs) != 1 {
+			subT.Fatalf("Then number of proxy configs does not match. Expected [%d]; got [%d]", 1, len(pList.ProxyConfigs))
+		}
+	})
+}

--- a/client/testdata/account_proxy_fixture.json
+++ b/client/testdata/account_proxy_fixture.json
@@ -1,0 +1,126 @@
+{
+  "proxy_configs": [
+    {
+      "proxy_config": {
+        "id": 5,
+        "version": 1,
+        "environment": "production",
+        "content": {
+          "id": 2,
+          "account_id": 4,
+          "name": "API 1",
+          "oneline_description": null,
+          "description": null,
+          "txt_api": null,
+          "txt_support": null,
+          "txt_features": null,
+          "created_at": "2023-01-17T11:39:19Z",
+          "updated_at": "2023-02-21T17:38:18Z",
+          "logo_file_name": null,
+          "logo_content_type": null,
+          "logo_file_size": null,
+          "state": "incomplete",
+          "intentions_required": false,
+          "draft_name": "",
+          "infobar": null,
+          "terms": null,
+          "display_provider_keys": false,
+          "tech_support_email": null,
+          "admin_support_email": null,
+          "credit_card_support_email": null,
+          "buyers_manage_apps": true,
+          "buyers_manage_keys": true,
+          "custom_keys_enabled": true,
+          "buyer_plan_change_permission": "request",
+          "buyer_can_select_plan": false,
+          "notification_settings": null,
+          "default_application_plan_id": 0,
+          "default_service_plan_id": 0,
+          "default_end_user_plan_id": null,
+          "end_user_registration_required": false,
+          "tenant_id": 2,
+          "system_name": "service_tpeyauhi",
+          "backend_version": "1",
+          "mandatory_app_key": true,
+          "buyer_key_regenerate_enabled": true,
+          "support_email": "user@example.com",
+          "referrer_filters_required": false,
+          "deployment_option": "hosted",
+          "proxiable?": true,
+          "backend_authentication_type": "service_token",
+          "backend_authentication_value": "79",
+          "proxy": {
+            "id": 327585,
+            "tenant_id": 2,
+            "service_id": 2555417981501,
+            "endpoint": "https://service-tpeyauhi-2.production.example.com:443",
+            "deployed_at": null,
+            "api_backend": "https://echo-api.3scale.net:443",
+            "auth_app_key": "app_key",
+            "auth_app_id": "app_id",
+            "auth_user_key": "user_key",
+            "credentials_location": "query",
+            "error_auth_failed": "Authentication failed",
+            "error_auth_missing": "Authentication parameters missing",
+            "created_at": "2023-01-17T11:39:19Z",
+            "updated_at": "2023-02-21T17:38:18Z",
+            "error_status_auth_failed": 403,
+            "error_headers_auth_failed": "text/plain; charset=us-ascii",
+            "error_status_auth_missing": 403,
+            "error_headers_auth_missing": "text/plain; charset=us-ascii",
+            "error_no_match": "No Mapping Rule matched",
+            "error_status_no_match": 404,
+            "error_headers_no_match": "text/plain; charset=us-ascii",
+            "secret_token": "Shared_secret",
+            "hostname_rewrite": null,
+            "oauth_login_url": null,
+            "sandbox_endpoint": "https://service-tpeyauhi-2.staging.example.com:443",
+            "api_test_path": "/",
+            "api_test_success": null,
+            "apicast_configuration_driven": true,
+            "oidc_issuer_endpoint": null,
+            "lock_version": 1,
+            "authentication_method": "1",
+            "hostname_rewrite_for_sandbox": "echo-api.3scale.net",
+            "endpoint_port": 443,
+            "valid?": true,
+            "service_backend_version": "1",
+            "hosts": [
+              "service-tpeyauhi-2.production.example.com",
+              "service-tpeyauhi-2.staging.example.com"
+            ],
+            "backend": {
+              "endpoint": "https://example.com",
+              "host": "example.com"
+            },
+            "policy_chain": [
+              {
+                "name": "apicast",
+                "version": "builtin",
+                "configuration": {}
+              }
+            ],
+            "proxy_rules": [
+              {
+                "id": 966312,
+                "proxy_id": 327585,
+                "http_method": "GET",
+                "pattern": "/",
+                "metric_id": 2555419020711,
+                "metric_system_name": "hits",
+                "delta": 1,
+                "tenant_id": 2,
+                "created_at": "2023-01-17T11:39:19Z",
+                "updated_at": "2023-01-17T11:39:19Z",
+                "redirect_url": null,
+                "parameters": [],
+                "querystring_parameters": {},
+                "position": 1
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
Implement new endpoint `GET /admin/api/account/proxy_configs/%s.json`.

Added pagination params `page`, `per_page`

### Verification steps

* Create > 500 products in one tenant. Promote the product configuration to staging or production. 
* Run `ListAccountProxyConfigs` method and verify all the proxy_configs (1 per product) are in the response. It should be >500. `account_proxy_config_latest_read.go` file
```go
func main() {                                                                                   
    var (                                                                                       
        env     string  = "sandbox"                                                          
        version *string = &[]string{"latest"}[0]                                                
        host *string                                                                            
    )                                                                                           
                                                      
    c := helper.Generic_client()      //     client.NewThreeScale(adminPortal, accessToken)                                                
    obj, err := c.ListAccountProxyConfigs(env, version, host)                                   
    if err != nil {                                                                             
        panic(err)                                                                              
    }                                                                                           
                                                                                                
    helper.PrintJson(obj)                                                                       
}                                                                                               

```

```
$ go run account_proxy_config_latest_read.go | jq '.proxy_configs | length'
550
```
