### PR TITLE
THREESCALE-9476 backend pagination

### DIFF
--- a/client/backend_api.go
+++ b/client/backend_api.go
@@ -4,28 +4,66 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
 const (
-	backendListResourceEndpoint       = "/admin/api/backend_apis.json"
-	backendResourceEndpoint           = "/admin/api/backend_apis/%d.json"
-	backendMethodListResourceEndpoint = "/admin/api/backend_apis/%d/metrics/%d/methods.json"
-	backendMethodResourceEndpoint     = "/admin/api/backend_apis/%d/metrics/%d/methods/%d.json"
-	backendMetricListResourceEndpoint = "/admin/api/backend_apis/%d/metrics.json"
-	backendMetricResourceEndpoint     = "/admin/api/backend_apis/%d/metrics/%d.json"
-	backendMRListResourceEndpoint     = "/admin/api/backend_apis/%d/mapping_rules.json"
-	backendMRResourceEndpoint         = "/admin/api/backend_apis/%d/mapping_rules/%d.json"
-	backendUsageListResourceEndpoint  = "/admin/api/services/%d/backend_usages.json"
-	backendUsageResourceEndpoint      = "/admin/api/services/%d/backend_usages/%d.json"
+	backendListResourceEndpoint           = "/admin/api/backend_apis.json"
+	backendResourceEndpoint               = "/admin/api/backend_apis/%d.json"
+	backendMethodListResourceEndpoint     = "/admin/api/backend_apis/%d/metrics/%d/methods.json"
+	backendMethodResourceEndpoint         = "/admin/api/backend_apis/%d/metrics/%d/methods/%d.json"
+	backendMetricListResourceEndpoint     = "/admin/api/backend_apis/%d/metrics.json"
+	backendMetricResourceEndpoint         = "/admin/api/backend_apis/%d/metrics/%d.json"
+	backendMRListResourceEndpoint         = "/admin/api/backend_apis/%d/mapping_rules.json"
+	backendMRResourceEndpoint             = "/admin/api/backend_apis/%d/mapping_rules/%d.json"
+	backendUsageListResourceEndpoint      = "/admin/api/services/%d/backend_usages.json"
+	backendUsageResourceEndpoint          = "/admin/api/services/%d/backend_usages/%d.json"
+	BACKENDS_PER_PAGE                 int = 500
 )
 
 // ListBackends List existing backends
 func (c *ThreeScaleClient) ListBackendApis() (*BackendApiList, error) {
+	// Keep asking until the results length is lower than "per_page" param
+	currentPage := 1
+	backendList := &BackendApiList{}
+
+	allResultsPerPage := false
+	for next := true; next; next = allResultsPerPage {
+		tmpBackendList, err := c.ListBackendApisPerPage(currentPage, BACKENDS_PER_PAGE)
+		if err != nil {
+			return nil, err
+		}
+
+		backendList.Backends = append(backendList.Backends, tmpBackendList.Backends...)
+
+		allResultsPerPage = len(tmpBackendList.Backends) == BACKENDS_PER_PAGE
+		currentPage += 1
+	}
+
+	return backendList, nil
+}
+
+// ListBackendApisPerPage List existing backends for a given page
+// paginationValues[0] = Page in the paginated list. Defaults to 1 for the API, as the client will not send the page param.
+// paginationValues[1] = Number of results per page. Default and max is 500 for the aPI, as the client will not send the per_page param.
+func (c *ThreeScaleClient) ListBackendApisPerPage(paginationValues ...int) (*BackendApiList, error) {
+	queryValues := url.Values{}
+
+	if len(paginationValues) > 0 {
+		queryValues.Add("page", strconv.Itoa(paginationValues[0]))
+	}
+
+	if len(paginationValues) > 1 {
+		queryValues.Add("per_page", strconv.Itoa(paginationValues[1]))
+	}
+
 	req, err := c.buildGetReq(backendListResourceEndpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	req.URL.RawQuery = queryValues.Encode()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {


### PR DESCRIPTION
#### what 

Fixes https://issues.redhat.com/browse/THREESCALE-9476

#### Verification steps

* Create > 500 backends in one tenant. 
* Run `ListBackendApis` method and verify all the backends are in the response. It should be >500. `backend_list.go` file
```go
func main() {                                                                                           
    c := helper.Generic_client()      //     client.NewThreeScale(adminPortal, accessToken)                                                
    obj, err := c.ListBackendApis()                                   
    if err != nil {                                                                             
        panic(err)                                                                              
    }                                                                                           
                                                                                                
    helper.PrintJson(obj)                                                                       
}                                                                                               

```

```
$ go run backend_list.go  | jq '.backend_apis|length'
551
```