### PR TITLE
Fetch multiple pages on developeraccount endpoint implementing page and per_page

### DIFF
--- a/client/developer_accounts.go
+++ b/client/developer_accounts.go
@@ -7,20 +7,58 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 )
 
 const (
-	developerAccountListResourceEndpoint = "/admin/api/accounts.json"
-	developerAccountResourceEndpoint     = "/admin/api/accounts/%d.json"
-	signupResourceEndpoint               = "/admin/api/signup.json"
+	developerAccountListResourceEndpoint     = "/admin/api/accounts.json"
+	developerAccountResourceEndpoint         = "/admin/api/accounts/%d.json"
+	signupResourceEndpoint                   = "/admin/api/signup.json"
+	DEVELOPERACCOUNTS_PER_PAGE           int = 500
 )
 
 func (c *ThreeScaleClient) ListDeveloperAccounts() (*DeveloperAccountList, error) {
+	// Keep asking until the results length is lower than "per_page" param
+	currentPage := 1
+	list := &DeveloperAccountList{}
+
+	allResultsPerPage := false
+	for next := true; next; next = allResultsPerPage {
+		tmpList, err := c.ListDeveloperAccountsPerPage(currentPage, DEVELOPERACCOUNTS_PER_PAGE)
+		if err != nil {
+			return nil, err
+		}
+
+		list.Items = append(list.Items, tmpList.Items...)
+
+		allResultsPerPage = len(tmpList.Items) == DEVELOPERACCOUNTS_PER_PAGE
+		currentPage += 1
+	}
+
+	return list, nil
+}
+
+// ListDeveloperAccountsPerPage List existing developer accounts for a given page
+// paginationValues[0] = Page in the paginated list. Defaults to 1 for the API, as the client will not send the page param.
+// paginationValues[1] = Number of results per page. Default and max is 500 for the aPI, as the client will not send the per_page param.
+func (c *ThreeScaleClient) ListDeveloperAccountsPerPage(paginationValues ...int) (*DeveloperAccountList, error) {
+	queryValues := url.Values{}
+
+	if len(paginationValues) > 0 {
+		queryValues.Add("page", strconv.Itoa(paginationValues[0]))
+	}
+
+	if len(paginationValues) > 1 {
+		queryValues.Add("per_page", strconv.Itoa(paginationValues[1]))
+	}
+
 	req, err := c.buildGetReq(developerAccountListResourceEndpoint)
 	if err != nil {
 		return nil, err
 	}
+
+	req.URL.RawQuery = queryValues.Encode()
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {

--- a/client/developer_accounts_test.go
+++ b/client/developer_accounts_test.go
@@ -7,51 +7,66 @@ import (
 	"io/ioutil"
 	"net/http"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 )
 
 func developerAccount1() DeveloperAccount {
-	var accountID int64 = 1
-
-	return DeveloperAccount{
-		Element: DeveloperAccountItem{
-			ID: &accountID,
-		},
-	}
-
+	return DeveloperAccount{Element: DeveloperAccountItem{ID: &[]int64{1}[0]}}
 }
 
 func developerAccount2() DeveloperAccount {
-	var accountID int64 = 2
-
-	return DeveloperAccount{
-		Element: DeveloperAccountItem{
-			ID: &accountID,
-		},
-	}
-
+	return DeveloperAccount{Element: DeveloperAccountItem{ID: &[]int64{2}[0]}}
 }
 
 func TestListDeveloperAccounts(t *testing.T) {
 	var (
 		endpoint = developerAccountListResourceEndpoint
-
-		list = DeveloperAccountList{
-			Items: []DeveloperAccount{
-				developerAccount1(),
-				developerAccount2(),
-			},
-		}
 	)
 
+	develAccountGenerator := func(startingIndex, n int) DeveloperAccountList {
+		pList := DeveloperAccountList{
+			Items: make([]DeveloperAccount, 0, n),
+		}
+
+		for idx := 0; idx < n; idx++ {
+			pList.Items = append(pList.Items, DeveloperAccount{
+				Element: DeveloperAccountItem{ID: &[]int64{int64(idx + startingIndex)}[0]},
+			})
+		}
+
+		return pList
+	}
+
 	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		// Will serve: 3 pages
+		// page 1 => DEVELOPERACCOUNTS_PER_PAGE
+		// page 2 => DEVELOPERACCOUNTS_PER_PAGE
+		// page 3 => 51
+
 		if req.URL.Path != endpoint {
 			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
 		}
 
 		if req.Method != http.MethodGet {
 			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+		}
+
+		if req.URL.Query().Get("per_page") != strconv.Itoa(DEVELOPERACCOUNTS_PER_PAGE) {
+			t.Fatalf("per_page param does not match. Expected [%d]; got [%s]", DEVELOPERACCOUNTS_PER_PAGE, req.URL.Query().Get("per_page"))
+		}
+
+		var list DeveloperAccountList
+
+		if req.URL.Query().Get("page") == "1" {
+			list = develAccountGenerator(DEVELOPERACCOUNTS_PER_PAGE*0, DEVELOPERACCOUNTS_PER_PAGE)
+		} else if req.URL.Query().Get("page") == "2" {
+			list = develAccountGenerator(DEVELOPERACCOUNTS_PER_PAGE*1, DEVELOPERACCOUNTS_PER_PAGE)
+		} else if req.URL.Query().Get("page") == "3" {
+			list = develAccountGenerator(DEVELOPERACCOUNTS_PER_PAGE*2, 51)
+		} else {
+			t.Fatalf("page param unexpected value; got [%s]", req.URL.Query().Get("page"))
 		}
 
 		responseBodyBytes, err := json.Marshal(list)
@@ -68,20 +83,127 @@ func TestListDeveloperAccounts(t *testing.T) {
 
 	credential := "someAccessToken"
 	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
-	resp, err := c.ListDeveloperAccounts()
+	list, err := c.ListDeveloperAccounts()
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	if resp == nil {
-		t.Fatal("response was nil")
+	if list == nil {
+		t.Fatal("developer account list returned nil")
 	}
 
-	if !reflect.DeepEqual(*resp, list) {
-		got, _ := json.Marshal(*resp)
-		expected, _ := json.Marshal(list)
-		t.Fatalf("Expected %s; got %s", string(expected), string(got))
+	if len(list.Items) != 2*DEVELOPERACCOUNTS_PER_PAGE+51 {
+		t.Fatalf("The number of developer accounts does not match. Expected [%d]; got [%d]", 2*DEVELOPERACCOUNTS_PER_PAGE+51, len(list.Items))
 	}
+}
+
+func TestListDeveloperAccountsPerPage(t *testing.T) {
+	var (
+		endpoint = developerAccountListResourceEndpoint
+	)
+
+	t.Run("page and per_page params used", func(subT *testing.T) {
+		var (
+			pageNum int = 4
+			perPage int = 2
+		)
+		httpClient := NewTestClient(func(req *http.Request) *http.Response {
+			if req.URL.Path != endpoint {
+				subT.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+			}
+
+			if req.Method != http.MethodGet {
+				subT.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+			}
+
+			if req.URL.Query().Get("page") != strconv.Itoa(pageNum) {
+				subT.Fatalf("page param does not match. Expected [%d]; got [%s]", pageNum, req.URL.Query().Get("page"))
+			}
+
+			if req.URL.Query().Get("per_page") != strconv.Itoa(perPage) {
+				subT.Fatalf("page param does not match. Expected [%d]; got [%s]", perPage, req.URL.Query().Get("per_page"))
+			}
+
+			list := DeveloperAccountList{
+				Items: []DeveloperAccount{developerAccount1(), developerAccount2()},
+			}
+
+			responseBodyBytes, err := json.Marshal(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+				Header:     make(http.Header),
+			}
+		})
+
+		credential := "someAccessToken"
+		c := NewThreeScale(NewTestAdminPortal(subT), credential, httpClient)
+		list, err := c.ListDeveloperAccountsPerPage(pageNum, perPage)
+		if err != nil {
+			subT.Fatal(err)
+		}
+
+		if list == nil {
+			subT.Fatal("developer account list returned nil")
+		}
+
+		if len(list.Items) != 2 {
+			subT.Fatalf("Then number of developer accounts does not match. Expected [%d]; got [%d]", 2, len(list.Items))
+		}
+	})
+
+	t.Run("page and per_page params not used", func(subT *testing.T) {
+		httpClient := NewTestClient(func(req *http.Request) *http.Response {
+			if req.URL.Path != endpoint {
+				subT.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+			}
+
+			if req.Method != http.MethodGet {
+				subT.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodGet, req.Method)
+			}
+
+			if req.URL.Query().Get("page") != "" {
+				subT.Fatalf("Query param page does not match. Expected empty; got [%s]", req.URL.Query().Get("page"))
+			}
+
+			if req.URL.Query().Get("per_page") != "" {
+				subT.Fatalf("page param does not match. Expected empty; got [%s]", req.URL.Query().Get("per_page"))
+			}
+
+			list := DeveloperAccountList{
+				Items: []DeveloperAccount{developerAccount1(), developerAccount2()},
+			}
+
+			responseBodyBytes, err := json.Marshal(list)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Body:       ioutil.NopCloser(bytes.NewBuffer(responseBodyBytes)),
+				Header:     make(http.Header),
+			}
+		})
+
+		credential := "someAccessToken"
+		c := NewThreeScale(NewTestAdminPortal(subT), credential, httpClient)
+		list, err := c.ListDeveloperAccountsPerPage()
+		if err != nil {
+			subT.Fatal(err)
+		}
+
+		if list == nil {
+			subT.Fatal("developer account list returned nil")
+		}
+
+		if len(list.Items) != 2 {
+			subT.Fatalf("Then number of developer account items does not match. Expected [%d]; got [%d]", 2, len(list.Items))
+		}
+	})
 }
 
 func TestReadDeveloperAccount(t *testing.T) {


### PR DESCRIPTION
#### what

- [X] developer account list pagination
~developer user list pagination~ (3scale 2.13 does not implement pages in developer user list endpoint)

#### verification steps

* Create > 500 developer accounts
* Run `ListDeveloperAccounts` method and verify all the develper account items are in the response. It should be >500. `developeraccount_list.go` file
```go
func main() {          
    c := helper.Generic_client()      //     client.NewThreeScale(adminPortal, accessToken)                                                
    obj, err := c.ListDeveloperAccounts()                                   
    if err != nil {                                                                             
        panic(err)                                                                              
    }                                                                                           
                                                                                                
    helper.PrintJson(obj)                                                                       
}                                                                                               

```

```
$ go run developeraccount_list.go | jq '.accounts | length'
551
```