### PR TITLE
feat: add missing `ApplicationId` to `Application` model

### DIFF
--- a/client/app_test.go
+++ b/client/app_test.go
@@ -523,6 +523,7 @@ func TestReadApplication(t *testing.T) {
 				PlanID:        planID,
 				UserAccountID: strconv.FormatInt(accountID, 10),
 				Description:   description,
+				ApplicationId: "7034ff61",
 			},
 		}
 	)

--- a/client/types.go
+++ b/client/types.go
@@ -41,6 +41,7 @@ type Application struct {
 	PlanID                  int64  `json:"plan_id"`
 	AppName                 string `json:"name"`
 	Description             string `json:"description"`
+	ApplicationId           string `json:"application_id"`
 	ExtraFields             string `json:"extra_fields"`
 	Error                   string `json:"error,omitempty"`
 }


### PR DESCRIPTION
The current Application model lacks an `ApplicationId` property, which it likely should include. When setting Authentication settings to `App_ID and App_Key Pair`, each response contains an `application_id`.

<img width="286" alt="Screenshot 2024-02-07 at 18 24 58" src="https://github.com/3scale/3scale-porta-go-client/assets/17556031/cf0b3853-d564-4e77-9e6d-0fac8ef218c2">