### PR TITLE
feat: add handler for application keys endpoint

### DIFF
--- a/client/app.go
+++ b/client/app.go
@@ -19,6 +19,7 @@ const (
 	appDeletePlanCustomization = "/admin/api/accounts/%d/applications/%d/decustomize_plan.json"
 	appSuspend                 = "/admin/api/accounts/%d/applications/%d/suspend.json"
 	appResume                  = "/admin/api/accounts/%d/applications/%d/resume.json"
+	appKeys                    = "/admin/api/accounts/%d/applications/%d/keys.json"
 	listAllApplications        = "/admin/api/applications.json"
 )
 
@@ -220,6 +221,32 @@ func (c *ThreeScaleClient) ApplicationResume(accountId, id int64) (*Application,
 		return nil, err
 	}
 	return &apiResp.Application, nil
+}
+
+func (c *ThreeScaleClient) ApplicationKeys(accountId, id int64) ([]ApplicationKey, error) {
+	endpoint := fmt.Sprintf(appKeys, accountId, id)
+
+	req, err := c.buildGetReq(endpoint)
+	if err != nil {
+		return nil, httpReqError
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	apiResp := &ApplicationKeysElem{}
+	err = handleJsonResp(resp, http.StatusOK, apiResp)
+	if err != nil {
+		return nil, err
+	}
+	var keys []ApplicationKey
+	for _, key := range apiResp.Keys {
+		keys = append(keys, key.Key)
+	}
+	return keys, nil
 }
 
 func (c *ThreeScaleClient) Application(accountId, id int64) (*Application, error) {

--- a/client/app.go
+++ b/client/app.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -20,6 +21,8 @@ const (
 	appSuspend                 = "/admin/api/accounts/%d/applications/%d/suspend.json"
 	appResume                  = "/admin/api/accounts/%d/applications/%d/resume.json"
 	appKeys                    = "/admin/api/accounts/%d/applications/%d/keys.json"
+	appKeyCreate               = "/admin/api/accounts/%d/applications/%d/keys.json"
+	appKeyDelete               = "/admin/api/accounts/%d/applications/%d/keys/%s.json"
 	listAllApplications        = "/admin/api/applications.json"
 )
 
@@ -247,6 +250,60 @@ func (c *ThreeScaleClient) ApplicationKeys(accountId, id int64) ([]ApplicationKe
 		keys = append(keys, key.Key)
 	}
 	return keys, nil
+}
+func (c *ThreeScaleClient) CreateApplicationRandomKey(accountId, id int64) (Application, error) {
+	return c.createApplicationKey(accountId, id, nil)
+}
+
+func (c *ThreeScaleClient) CreateApplicationKey(accountId, id int64, key string) (Application, error) {
+	return c.createApplicationKey(accountId, id, &key)
+}
+
+func (c *ThreeScaleClient) createApplicationKey(accountId, id int64, key *string) (Application, error) {
+	var app Application
+	endpoint := fmt.Sprintf(appKeyCreate, accountId, id)
+
+	var body io.Reader
+	if key != nil {
+		values := url.Values{}
+		values.Add("key", *key)
+		body = strings.NewReader(values.Encode())
+	}
+
+	req, err := c.buildPostReq(endpoint, body)
+	if err != nil {
+		return app, httpReqError
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return app, err
+	}
+	defer resp.Body.Close()
+
+	apiResp := &ApplicationElem{}
+	err = handleJsonResp(resp, http.StatusCreated, apiResp)
+	if err != nil {
+		return app, err
+	}
+	return apiResp.Application, nil
+}
+
+func (c *ThreeScaleClient) DeleteApplicationKey(accountID, id int64, key string) error {
+	endpoint := fmt.Sprintf(appKeyDelete, accountID, id, key)
+
+	req, err := c.buildDeleteReq(endpoint, nil)
+	if err != nil {
+		return err
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	return handleJsonResp(resp, http.StatusOK, nil)
 }
 
 func (c *ThreeScaleClient) Application(accountId, id int64) (*Application, error) {

--- a/client/app_test.go
+++ b/client/app_test.go
@@ -567,6 +567,38 @@ func TestCreateApplicationKey(t *testing.T) {
 	}
 }
 
+func TestDeleteApplicationKey(t *testing.T) {
+	var (
+		appID          int64 = 12
+		accountID      int64 = 321
+		applicationKey       = "4efd48e3e2ecfdea1fc21eeddf0610b9"
+		endpoint             = fmt.Sprintf(appKeyDelete, accountID, appID, applicationKey)
+	)
+
+	httpClient := NewTestClient(func(req *http.Request) *http.Response {
+		if req.URL.Path != endpoint {
+			t.Fatalf("Path does not match. Expected [%s]; got [%s]", endpoint, req.URL.Path)
+		}
+
+		if req.Method != http.MethodDelete {
+			t.Fatalf("Method does not match. Expected [%s]; got [%s]", http.MethodDelete, req.Method)
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+		}
+	})
+
+	credential := "someAccessToken"
+	c := NewThreeScale(NewTestAdminPortal(t), credential, httpClient)
+	err := c.DeleteApplicationKey(accountID, appID, applicationKey)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestApplicationKeys(t *testing.T) {
 	var (
 		appID          int64 = 12

--- a/client/types.go
+++ b/client/types.go
@@ -55,6 +55,23 @@ type ApplicationList struct {
 	Applications []ApplicationElem `json:"applications"`
 }
 
+// ApplicationKeysElem - Holds a list of applications keys
+type ApplicationKeysElem struct {
+	Keys []ApplicationKeyWrapper `json:"keys"`
+}
+
+// ApplicationKey - Holds a application key
+type ApplicationKeyWrapper struct {
+	Key ApplicationKey `json:"key"`
+}
+
+// ApplicationKey - Holds a application key
+type ApplicationKey struct {
+	Value     string `json:"value"`
+	CreatedAt string `json:"created_at"`
+	UpdatedAt string `json:"updated_at"`
+}
+
 // ApplicationPlansList - Holds a list of application plans
 // Deprecated. Use ApplicationPlanJSONList instead
 type ApplicationPlansList struct {


### PR DESCRIPTION
# Scope of changes
- Added a handler for fetching application keys from the `/admin/api/accounts/%d/applications/%d/keys.json` endpoint.